### PR TITLE
added try except for compatibility conda freecad

### DIFF
--- a/src/GEOReverse/__init__.py
+++ b/src/GEOReverse/__init__.py
@@ -1,0 +1,8 @@
+# this try except attempts to import freecad (lowercase) which is the conda
+# package name for FreeCAD (mixed case) upon import the conda package appends
+# the sys path for Conda installed FreeCAD, consequently FreeCAD can then be
+# found by subsequent import statements through out the code base
+try:
+    import freecad
+except:
+    pass

--- a/src/GEOUNED/__init__.py
+++ b/src/GEOUNED/__init__.py
@@ -3,6 +3,14 @@
 
 # We load the STEP and the materials
 import sys
+# this try except attempts to import freecad (lowercase) which is the conda
+# package name for FreeCAD (mixed case) upon import the conda package appends
+# the sys path for Conda installed FreeCAD, consequently FreeCAD can then be
+# found by subsequent import statements through out the code base
+try:
+    import freecad
+except:
+    pass
 import FreeCAD,Part
 import configparser
 


### PR DESCRIPTION
Thanks for reviewing and merging the last couple of PRs.

This one is another small minimal PR that would allow GEOUNED to work with the conda freecad package.

Conda freecad package provides compiled FreeCAD.so files, compiled to be compatible with the conda python.

The means we can make use of geouned with our system python :tada: instead of the ```FreeCAD.cmd``` command and also we can avoid manually appending paths to the sys :tada:.

The conda freecad package is distributed under the name ```freecad``` lower case and once imported it would add the path to the appropriately compile FreeCAD.so and then one can import FreeCAD and it know where to find the .so file.

If the ```try:``` fails then it will pass the except and therefore this has no impact on the other ways of running the package.

I've tested the installation of GEOUNED package with conda freecad on windows, mac and ubuntu with python versions 3.8 and 3.11 and converted all 52 step files found in the testing folder. The CI for this testing is [here ](https://github.com/shimwell/GEOUNED/actions/runs/8690234940) if that is of interest.

Supporting the conda package for freecad also has the potential to reduce the installation to a single command which is something I can add in the future if this PR goes ahead

Many thanks for considering this PR

Tagging @aljaz-kolsek for your interest