### PR TITLE
Added mkdocs

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,13 @@
+# Examples
+
+## Conversion of CAD to CSG
+
+
+The following code snippet will convert a CAD file in the STEP format called example.step into and XML file called geometry.xml that can be opened and run with OpenMC
+
+    import geouned
+    geouned.cad_to_csg(
+        cad_filename='example.step',
+        output_filename='geometry.xml',
+        csg_format='openmc'
+    )

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Welcome to GEOUNED documentation
+
+GEOUNED converts CAD geometry to CGS and CGS to CAD.
+
+
+The CSG geometry produced is compatible with Monte Carlo particle transport codes such as [OpenMC](https://github.com/openmc-dev/openmc) and [MCNP](https://mcnp.lanl.gov/).
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,59 @@
+# Installation
+
+Recommended method of installing is to make use of Conda / Mamba.
+This results in installation of GEOUNED with your system Python and the most straightforward usage.
+
+There are other options which are also documented.
+The main difference between the installation options is the manner in which the main dependency FreeCAD is installed and this has consequences for how the code is used.
+
+With some options (Conda) offering integration of FreeCAD Python API into your system Python and other options requiring GEOUNED scripts to be run with freecadcmd or freecad.cmd and integration of GEOUNED and FreeCAD performed with system path appending or freecad.pip 
+
+## Linux (Ubuntu)
+
+### Conda
+
+
+In principle, installing any Conda/Mamba distribution will work. A few Conda/Mamba options are:
+- [Miniforge](https://github.com/conda-forge/miniforge)
+- [Anaconda](https://www.anaconda.com/download)
+- [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
+
+In this example we will install Miniforge (which includes Mamba)
+```bash
+wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+```
+
+Create a new environment, I've chosen Python 3.10 here but newer versions are
+also supported.
+```bash
+mamba create --name new_env python=3.10 -y
+```
+
+Activate the environment
+```bash
+mamba activate new_env
+```
+
+Then you can install the cad_to_dagmc package
+```bash
+mamba install -y -c conda-forge geouned
+```
+
+### AppImage
+
+### Apt-get
+
+### Snap
+
+
+
+## Mac OS
+
+### Conda
+
+## Windows
+
+### Conda
+
+### Portable FreeCAD
+

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -1,0 +1,9 @@
+# Python API
+
+::: geouned.cad_to_csg
+    options:
+      show_source: true
+
+::: geouned.csg_to_cad
+    options:
+      show_source: true

--- a/docs/theory_and_methodology.md
+++ b/docs/theory_and_methodology.md
@@ -1,0 +1,4 @@
+# Theory and Methodology
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: GEOUNED
+site_url: https://github.com/GEOUNED-org/GEOUNED/deployments/github-pages
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Examples: examples.md
+  - Python API: python_api.md
+  - Theory and Methodology: theory_and_methodology.md
+theme: readthedocs
+plugins:
+- search
+- mkdocstrings:
+    handlers:
+      python:
+        paths: [src]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,7 @@ Documentation = "https://github.com/GEOUNED-org/GEOUNED/docs"
 tests = [
     "pytest",
 ]
+docs = [
+    "mkdocs",
+    "mkdocstrings[python]>=0.18",
+]


### PR DESCRIPTION
Also needs a random function to show docstrings for

```
import typing

def csg_to_cad(
    csg_filename: str,
    csg_format: str,
    output_filename: str,
    bounding_box: typing.Tuple(float),
) -> str:
    """Converts a CSG geometry into a CAD geometry and saves a STEP file

    Args:
        csg_filename (str): the filename of the CSG file
        csg_format (str): the format / Monte Carlo code of the CSG file.
            Acceptable options are 'openmc', 'mcnp', 'serpent'
        bounding_box (typing.Tuple): A bounding box for the geometry in the
            format lower left x,y,z and upper right x,y,z
        output_filename (str): the filename of the produced CAD file

    Returns:
        str: output file path of the CAD file produced
    """
    return 'hello world'

def cad_to_csg(
    cad_filename: str,
    csg_format: str,
    output_filename: str,
    start_cell_id: int,
) -> str:
    """Converts a CAD geometry into a CSG geometry in the specified format

    Args:
        cad_filename (str): the filename of the CAD file
        csg_format (str): the format / Monte Carlo code of the CSG file.
            Acceptable options are 'openmc', 'mcnp', 'serpent'
        output_filename (str): the filename of the produced CSG file
        start_cell_id (typing.Tuple): A bounding box for the geometry in the
            format lower left x,y,z and upper right x,y,z

    Returns:
        str: output file path of the CSG file produced
    """
    return 'hello world'
```