### PR TITLE
transport tests - reduced number of skipped models

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -34,7 +34,7 @@ def test_conversion(input_step_file):
         "cellSummaryFile = False\n"
         "cellCommentFile = False\n"
         "debug = False\n"
-        "simplify = full\n"
+        "simplify = no\n"
         "[Options]\n"
         "forceCylinder = False\n"
         "splitTolerance = 0\n"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -30,13 +30,10 @@ step_files = list(path_to_cad.rglob("*.stp")) + list(path_to_cad.rglob("*.step")
 step_files.remove(Path("testing/inputSTEP/large/SCDR.stp"))
 step_files.remove(Path("testing/inputSTEP/placa.stp"))
 step_files.remove(Path("testing/inputSTEP/placa2.stp"))
-step_files.remove(Path("testing/inputSTEP/Misc/sphereBarCyl2.stp"))
-step_files.remove(Path("testing/inputSTEP/Misc/sphereBarCyl1.stp"))
 # required a few more particles needed but also losing particles
 step_files.remove(Path("testing/inputSTEP/DoubleCylinder/placa3.step"))
 step_files.remove(Path("testing/inputSTEP/DoubleCylinder/placa.stp"))
 # this face2.stp crashes when loading the geometry.xml
-step_files.remove(Path("testing/inputSTEP/Torus/face2.stp"))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
this just changes the method of conversion from simplify fully to simplify no

this produces "better" geometry in some cases and therefore we no longer have to skip the CI testing transport for a few geometries geometries.

there remains five volumes that are not passing the CI