### PR TITLE
added pypi publish action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,25 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR adds an action for automated pypi publishing

When a release is published then this action will make a pypi package for geouned.

Someone will have to make a pypi account and follow these steps to add a trusted publisher. 
I am happy to help maintain the pypi package over on pypi.org if that helps and also happy to jump on a teams call to walk through the process.

https://docs.pypi.org/trusted-publishers/adding-a-publisher/#:~:text=Adding%20a%20trusted%20publisher%20to%20a%20PyPI,requires%20a%20single%20setup%20step.&text=That%20link%20will%20take%20you,(such%20as%20GitHub%20Actions).