### PR TITLE
camel case for all classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             python -m pip install --upgrade pip
             python -m pip install .
             python -c 'import geouned'
-            python -c 'from geouned import GEOUNED'
+            python -c 'from geouned import CadToCsg'
             python -c 'from geouned.GEOReverse import reverse'
             python -m pip install .[tests]
 

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,11 @@ cython_debug/
 # testing folder
 tests_outputs/
 
+# debug output folders
+fuzzySurfaces
+Suspicious_solids/
+Warning_Solids_definition.txt
+
 .vscode
 **/__pycache__
 docs/source/_build/**

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The second step is to call or GEOUNED for CAD to CSG conversion or GEOReverse fo
 From CAD to CSG:
 
 ```python
-from geouned import GEOUNED
+from geouned import CadToCsg
 inifile='Name of config file for forward conversion'
-GEO = GEOUNED(inifile)
+GEO = CadToCsg(inifile)
 GEO.SetOptions()
 GEO.Start()
 ``` 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: GNU General Public License v3.0",
+    "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
     "Operating System :: OS Independent",
 ]
 

--- a/scripts/geouned
+++ b/scripts/geouned
@@ -10,7 +10,7 @@ sys.path.append(geo_path)
 # linux distribution
 sys.path.append('/usr/lib64/freecad/lib64/')
 
-import geouned
+from geouned import CadToCsg
 from geouned.GEOReverse import reverse
 
 runReverse = False
@@ -38,7 +38,7 @@ else:
 
 
 if not runReverse :
-  GEO = GEOUNED.GEOUNED(inifile)
+  GEO = CadToCsg(inifile)
   GEO.SetOptions()
   GEO.Start()
 

--- a/scripts/geouned.py
+++ b/scripts/geouned.py
@@ -10,7 +10,7 @@ import sys
 # sys.path.append(geo_path)
 # sys.path.append('C:\\Program Files\\FreeCAD 0.19\\bin...')
 
-import geouned
+from geouned import CadToCsg
 from geouned.GEOReverse import reverse
 
 runReverse = False
@@ -38,7 +38,7 @@ else:
     raise ValueError("Too many input arguments")
 
 if not runReverse:
-    GEO = GEOUNED.GEOUNED(inifile)
+    GEO = CadToCsg(inifile)
     GEO.SetOptions()
     GEO.Start()
 

--- a/src/geouned/GEOReverse/Modules/MCNPinput.py
+++ b/src/geouned/GEOReverse/Modules/MCNPinput.py
@@ -8,10 +8,10 @@ from numpy import linalg as LA
 
 from .Objects import *
 from .Parser import parser as mp
-from .remh import cell_card_string, remove_hash
+from .remh import CellCardString, remove_hash
 
 
-class MCNPinput:
+class McnpInput:
     def __init__(self, name):
         if not os.path.isfile(name):
             raise FileNotFoundError(f"File {name} does not exist")
@@ -59,7 +59,7 @@ class MCNPinput:
             # set cell as CAD cell Object
             for cname, c in universe.items():
                 # print(cname,c.geom.str)
-                universe[cname] = CADCell(c)
+                universe[cname] = CadCell(c)
 
         return levels, FilteredCells, newSurfaces
 
@@ -72,7 +72,7 @@ class MCNPinput:
             if c.ctype != mp.CID.cell:
                 continue
             c.get_values()
-            cstr = cell_card_string("".join(c.lines))
+            cstr = CellCardString("".join(c.lines))
 
             if cstr.TRCL:
                 cstr.TRCL = TransformationMatrix(cstr.TRCL, self.Transformations)

--- a/src/geouned/GEOReverse/Modules/Objects.py
+++ b/src/geouned/GEOReverse/Modules/Objects.py
@@ -5,11 +5,11 @@ import numpy as np
 import Part
 
 from .buildSolidCell import BuildSolid
-from .remh import cline
+from .remh import Cline
 from .Utils.booleanFunction import BoolSequence, outterTerms
 
 
-class CADCell:
+class CadCell:
     def __init__(self, stringCell=None):
 
         if not stringCell:
@@ -44,14 +44,14 @@ class CADCell:
             self.__setDefinition__(stringCell)
 
     def copy(self):
-        cpCell = CADCell()
+        cpCell = CadCell()
         cpCell.surfaceList = self.surfaceList[:]
         cpCell.surfaces = {}
         for name, s in self.surfaces.items():
             cpCell.surfaces[name] = s.copy()
 
-        if type(self.definition) is cline:
-            cpCell.definition = cline(self.definition.str)
+        if type(self.definition) is Cline:
+            cpCell.definition = Cline(self.definition.str)
 
         elif type(self.definition) is BoolSequence:
             cpCell.definition = self.definition.copy()
@@ -115,7 +115,7 @@ class CADCell:
     #        subCellList=[]
     #        for df in subDefList:
     #           subCell = self.copy()
-    #           subCell.definition= cline(df)
+    #           subCell.definition= Cline(df)
     #           subCell.shape = None
     #           subCell.surfaceList  = subCell.definition.getSurfacesNumbers()
     #           for s in tuple(subCell.surfaces.keys()) :

--- a/src/geouned/GEOReverse/Modules/Parser/parser.py
+++ b/src/geouned/GEOReverse/Modules/Parser/parser.py
@@ -53,7 +53,7 @@ fmt_s = fmt_gen
 partial_formmatter = PartialFormatter()
 
 
-class __CIDClass(object):
+class CidClass(object):
     """
     There are two levels of card types. 1-st level is purely defined by card
     position in the input file.  There can be:
@@ -95,7 +95,7 @@ class __CIDClass(object):
             raise ValueError()
 
 
-CID = __CIDClass()
+CID = CidClass()
 
 
 class Card(object):

--- a/src/geouned/GEOReverse/Modules/XMLParser.py
+++ b/src/geouned/GEOReverse/Modules/XMLParser.py
@@ -1,7 +1,7 @@
-from .remh import cline
+from .remh import Cline
 
 
-class cellCARD:
+class CellCard:
 
     def __init__(self, data):
         self.type = "cell"
@@ -27,10 +27,10 @@ class cellCARD:
         else:
             self.FILL = None
 
-        self.geom = cline(data["region"].replace("|", ":"))
+        self.geom = Cline(data["region"].replace("|", ":"))
 
 
-class surfCARD:
+class SurfCard:
     def __init__(self, data):
 
         self.type = "surface"
@@ -50,7 +50,7 @@ def get_cards(root):
 def process_card(card):
     ctype = card.tag
     if ctype == "cell":
-        return cellCARD(card.attrib)
+        return CellCard(card.attrib)
 
     elif ctype == "surface":
-        return surfCARD(card.attrib)
+        return SurfCard(card.attrib)

--- a/src/geouned/GEOReverse/Modules/XMLinput.py
+++ b/src/geouned/GEOReverse/Modules/XMLinput.py
@@ -11,7 +11,7 @@ from .Objects import *
 from .XMLParser import get_cards
 
 
-class XMLinput:
+class XmlInput:
     def __init__(self, name):
         if not os.path.isfile(name):
             raise FileNotFoundError(f"File {name} does not exist")
@@ -61,7 +61,7 @@ class XMLinput:
             # set cell as CAD cell Object
             for cname, c in universe.items():
                 # print(cname,c.geom.str)
-                universe[cname] = CADCell(c)
+                universe[cname] = CadCell(c)
 
         return levels, FilteredCells, newSurfaces
 

--- a/src/geouned/GEOReverse/Modules/buildSolidCell.py
+++ b/src/geouned/GEOReverse/Modules/buildSolidCell.py
@@ -1,7 +1,7 @@
 import Part
 
 from .options import Options
-from .splitFunction import SplitSolid, joinBase, splitBase
+from .splitFunction import SplitSolid, joinBase, SplitBase
 from .Utils.booleanFunction import BoolSequence
 
 
@@ -21,7 +21,7 @@ def BuildSolid(cell, boundBox, mode="oneByOne", simplify=False):
     # cell.definition = BoolSequence(cell.definition.str)
     cell.cleanUndefined()
 
-    celParts = BuildDepth(cell, splitBase(cutCell), mode, True, simplify)
+    celParts = BuildDepth(cell, SplitBase(cutCell), mode, True, simplify)
 
     celParts = getPart(celParts)
     # print('celparts',len(celParts))

--- a/src/geouned/GEOReverse/Modules/remh.py
+++ b/src/geouned/GEOReverse/Modules/remh.py
@@ -190,7 +190,7 @@ def reverse_repl(m):
 
 def complementary(ccell, outter=True):
     """return the complementary cell"""
-    wrkcell = cline(ccell.str)
+    wrkcell = Cline(ccell.str)
     if wrkcell.str[-1] == "\n":
         wrkcell.str = wrkcell.str[:-1]
 
@@ -237,12 +237,12 @@ def complementary(ccell, outter=True):
 
 
 ############################################################
-class cline:
+class Cline:
     def __init__(self, line):
         self.str = line
 
     def copy(self):
-        return cline(self.str)
+        return Cline(self.str)
 
     def getSurfacesNumbers(self):
         s = set(unsignedint.findall(self.str))
@@ -301,7 +301,7 @@ class cline:
         return
 
     def outterTerms(self):
-        cgeom = cline(self.str)
+        cgeom = Cline(self.str)
 
         cgeom.remove_comments(full=True)
         cgeom.remove_redundant()
@@ -434,7 +434,7 @@ class cline:
                 count -= 1
             if count == 0:
                 end = p.end()
-                cell = cline(self.str[start + 1 : end])
+                cell = Cline(self.str[start + 1 : end])
                 break
         return cell, end
 
@@ -532,7 +532,7 @@ class cline:
 
 
 ############################################################
-class cell_card_string:
+class CellCardString:
 
     def __init__(self, card):
         self.stat = {"word": None, "hashcell": None, "hashsurf": None, "hash": None}
@@ -549,8 +549,8 @@ class cell_card_string:
     def __card_split__(self, cardin):
         """Split the card string in three parts :
            - headstr : string containing the cell name, mat number and density (if mat != 0) of the cell
-           - geom    : cline class containing the part of the geometric definition of the cell
-           - param    : cline class containing the cell parameters part
+           - geom    : Cline class containing the part of the geometric definition of the cell
+           - param    : Cline class containing the cell parameters part
         hproc is true if the complementary operator of the cell can be substituted"""
 
         m = celmat.match(cardin)
@@ -560,8 +560,8 @@ class cell_card_string:
         if m.group("scnd").lower() == "like":
             self.headstr = cardin[: m.start("scnd")]
             s = likebut.search(cardin, m.end("scnd"))
-            self.geom = cline(cardin[m.start("scnd") : s.end()])
-            self.parm = cline(cardin[s.end() :])
+            self.geom = Cline(cardin[m.start("scnd") : s.end()])
+            self.parm = Cline(cardin[s.end() :])
             self.hproc = False
             mc = unsignedint.search(self.geom.str)
             self.likeCell = int(mc.group())
@@ -578,7 +578,7 @@ class cell_card_string:
 
         if self.hproc:
             self.headstr = cardin[:cstart]
-            cellcard = cline(cardin[cstart:])
+            cellcard = Cline(cardin[cstart:])
             cellcard.remove_comments()
             m = param.search(cellcard.str)
             if m:
@@ -599,8 +599,8 @@ class cell_card_string:
 
             if m:
                 start = m.end(1)
-                self.geom = cline(cellcard.str[:start])
-                self.parm = cline(cellcard.str[start:])
+                self.geom = Cline(cellcard.str[:start])
+                self.parm = Cline(cellcard.str[start:])
 
                 # look for transformation in cell parameters
                 self.parm.remove_comments()
@@ -609,8 +609,8 @@ class cell_card_string:
                     self.hproc = False
                 self.parm.restore_comments()
             else:
-                self.geom = cline(cellcard.str)
-                self.parm = cline("")
+                self.geom = Cline(cellcard.str)
+                self.parm = Cline("")
 
         return
 
@@ -717,7 +717,7 @@ def remove_hash(cards, cname, keepComments=True):
         """remove complementary operator and subtitute by complementary cell"""
         if "parser.Card" in str(type(card)):
             celline = "".join(card.lines)
-            cardstr = cell_card_string(celline)
+            cardstr = CellCardString(celline)
         else:
             cardstr = card
         cardstr.get_stat()
@@ -726,7 +726,7 @@ def remove_hash(cards, cname, keepComments=True):
             return (
                 cardstr.geom
             )  # no complementary operator or cannot be # cannot be removed
-        cell = cline(cardstr.geom.str)
+        cell = Cline(cardstr.geom.str)
         # find all operators in the cell and
         # substitute all complementary operators
         # locate object in list to reverse iteration
@@ -753,7 +753,7 @@ def remove_hash(cards, cname, keepComments=True):
             if m.group(1) == "(":  # complementary cell defined as surface intersections
                 hcell, end = cell.get_hashcell(start)
                 cellmod = cell.str[0:start] + complementary(hcell) + cell.str[end:]
-                cell = cline(cellmod)
+                cell = Cline(cellmod)
             else:
                 hcname = int(
                     m.group(1)
@@ -769,8 +769,8 @@ def remove_hash(cards, cname, keepComments=True):
                     + " "
                     + cell.str[end:]
                 )
-                cell = cline(cellmod)
+                cell = Cline(cellmod)
         return cell
 
     newcell = remove(cards[cname], cname, keepComments)
-    return cline(newcell.str)
+    return Cline(newcell.str)

--- a/src/geouned/GEOReverse/Modules/splitFunction.py
+++ b/src/geouned/GEOReverse/Modules/splitFunction.py
@@ -5,7 +5,7 @@ import FreeCAD
 import Part
 
 
-class splitBase:
+class SplitBase:
     def __init__(self, base, knownSurf={}):
         self.base = base
         self.knownSurf = knownSurf
@@ -31,7 +31,7 @@ def joinBase(baseList):
                     removedKeys.append(k)
 
     newbase = FuseSolid(shape)
-    return splitBase(newbase, surf)
+    return SplitBase(newbase, surf)
 
 
 def SplitSolid(base, surfacesCut, cellObj, solidTool=False, tolerance=0.01):  # 1e-2
@@ -88,9 +88,9 @@ def SplitSolid(base, surfacesCut, cellObj, solidTool=False, tolerance=0.01):  # 
         #  sol.exportStep('solid_{}{}.stp'.format(name,ii))
 
         if inSolid:
-            fullPart.append(splitBase(sol, pos))
+            fullPart.append(SplitBase(sol, pos))
         elif inSolid is None:
-            cutPart.append(splitBase(sol, pos))
+            cutPart.append(SplitBase(sol, pos))
     return fullPart, cutPart
 
 

--- a/src/geouned/GEOReverse/__init__.py
+++ b/src/geouned/GEOReverse/__init__.py
@@ -1,8 +1,0 @@
-# this try except attempts to import freecad (lowercase) which is the conda
-# package name for FreeCAD (mixed case) upon import the conda package appends
-# the sys path for Conda installed FreeCAD, consequently FreeCAD can then be
-# found by subsequent import statements through out the code base
-try:
-    import freecad
-except:
-    pass

--- a/src/geouned/GEOReverse/reverse.py
+++ b/src/geouned/GEOReverse/reverse.py
@@ -3,10 +3,10 @@ import Import
 
 from .CodeVersion import *
 from .Modules.buildCAD import buildCAD, makeTree
-from .Modules.McnpInput import McnpInput
-from .Modules.Objects import CADCell
+from .Modules.MCNPinput import McnpInput
+from .Modules.Objects import CadCell
 from .Modules.processInp import setOptions
-from .Modules.XmlInput import XmlInput
+from .Modules.XMLinput import XmlInput
 
 
 def reverse(optFile="configRevese.ini"):

--- a/src/geouned/GEOReverse/reverse.py
+++ b/src/geouned/GEOReverse/reverse.py
@@ -3,10 +3,10 @@ import Import
 
 from .CodeVersion import *
 from .Modules.buildCAD import buildCAD, makeTree
-from .Modules.MCNPinput import MCNPinput
+from .Modules.McnpInput import McnpInput
 from .Modules.Objects import CADCell
 from .Modules.processInp import setOptions
-from .Modules.XMLinput import XMLinput
+from .Modules.XmlInput import XmlInput
 
 
 def reverse(optFile="configRevese.ini"):
@@ -28,14 +28,14 @@ def reverse(optFile="configRevese.ini"):
         "format": setting["inFormat"],
     }
 
-    UnivCell = CADCell()
+    UnivCell = CadCell()
     UnivCell.shape = UnivCell.makeBox(FreeCAD.BoundBox(*outBox))
 
     # get geometry definition from MCNP input
     if inFormat == "mcnp":
-        geom = MCNPinput(geomfile)
+        geom = McnpInput(geomfile)
     elif inFormat == "openMC_XML":
-        geom = XMLinput(geomfile)
+        geom = XmlInput(geomfile)
     else:
         msg = (
             f"input format type {inFormat} is not supported."

--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -18,7 +18,7 @@ from ..Utils.BasicFunctions_part1 import (
 )
 from ..Utils.booleanFunction import BoolSequence, insertInSequence
 from ..Utils.BooleanSolids import buildCTableFromSolids, removeExtraSurfaces
-from ..Utils.Functions import GEOUNED_Surface
+from ..Utils.Functions import GeounedSurface
 from ..Utils.Options.Classes import Options as opt
 from ..Utils.Options.Classes import Tolerances as tol
 
@@ -749,9 +749,9 @@ def cellDef(metaObj, Surfaces, UniverseBox):
         extraPlaneReverse = dict()
 
         flag_inv = isInverted(solid)
-        solid_GU = GU.solid_GU(solid)
+        SolidGu = GU.SolidGu(solid)
         lastTorus = -1
-        for iface, face in enumerate(solid_GU.Faces):
+        for iface, face in enumerate(SolidGu.Faces):
             surfaceType = str(face.Surface)
             if abs(face.Area) < tol.min_area:
                 if opt.verbose:
@@ -792,14 +792,14 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                 try:
                     plane = GenPlane(face, solid_GU)
                     if plane is not None:
-                        plane = GU.Plane_GU(plane)
+                        plane = GU.PlaneGu(plane)
                 except:
                     plane = None
                     if opt.verbose:
                         print("Warning: generation of additional plane has failed")
 
                 if plane is not None:
-                    p = GEOUNED_Surface(
+                    p = GeounedSurface(
                         ("Plane", (plane.Position, plane.Axis, plane.dim1, plane.dim2)),
                         UniverseBox,
                         Face="Build",
@@ -831,7 +831,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
 
                     idT = getId(face.Surface, Surfaces)
 
-                    index, Uparams = solid_GU.TorusUParams[iface]
+                    index, Uparams = SolidGu.TorusUParams[iface]
                     if index == lastTorus:
                         continue
                     lastTorus = index
@@ -843,7 +843,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                         planes, ORop = GenTorusAnnexUPlanes(face, UminMax)
                         plane1, plane2 = planes
 
-                        plane = GEOUNED_Surface(
+                        plane = GeounedSurface(
                             ("Plane", plane1), UniverseBox, Face="Build"
                         )
                         id1, exist = Surfaces.addPlane(plane)
@@ -855,7 +855,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                         if plane2 is None:
                             UVar = "%i" % id1
                         else:
-                            plane = GEOUNED_Surface(
+                            plane = GeounedSurface(
                                 ("Plane", plane2), UniverseBox, Face="Build"
                             )
                             id2, exist = Surfaces.addPlane(plane)
@@ -880,7 +880,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                         VVar = "-%i" % idT
 
                     else:
-                        index, Vparams = solid_GU.TorusVParams[iface]
+                        index, Vparams = SolidGu.TorusVParams[iface]
                         VClosed, VminMax = Vparams
                         if VClosed:
                             VVar = "%i" % idT
@@ -890,19 +890,19 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                             )
 
                             if surfType == "Cone":
-                                cone = GEOUNED_Surface(
+                                cone = GeounedSurface(
                                     ("Cone", surfParams), UniverseBox, Face="Build"
                                 )
                                 id2, exist = Surfaces.addCone(cone)
 
                             elif surfType == "Cylinder":
-                                cyl = GEOUNED_Surface(
+                                cyl = GeounedSurface(
                                     ("Cylinder", surfParams), UniverseBox, Face="Build"
                                 )
                                 id2, exist = Surfaces.addCylinder(cyl)
 
                             elif surfType == "Plane":
-                                plane = GEOUNED_Surface(
+                                plane = GeounedSurface(
                                     ("Plane", surfParams), UniverseBox, Face="Build"
                                 )
                                 id2, exist = Surfaces.addPlane(plane)
@@ -936,7 +936,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                     if surfaceType == "<Plane object>":
                         dim1 = face.ParameterRange[1] - face.ParameterRange[0]
                         dim2 = face.ParameterRange[3] - face.ParameterRange[2]
-                        plane = GEOUNED_Surface(
+                        plane = GeounedSurface(
                             (
                                 "Plane",
                                 (face.Surface.Position, face.Surface.Axis, dim1, dim2),
@@ -948,7 +948,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                         surf = plane.shape
                     elif surfaceType == "<Cylinder object>":
                         dimL = face.ParameterRange[3] - face.ParameterRange[2]
-                        cylinder = GEOUNED_Surface(
+                        cylinder = GeounedSurface(
                             (
                                 "Cylinder",
                                 (
@@ -1153,7 +1153,7 @@ def ExtraPlaneCylFace(face, Box, Surfaces):
             else:
                 dim1 = e.Curve.Radius
                 dim2 = e.Curve.Radius
-            plane = GEOUNED_Surface(
+            plane = GeounedSurface(
                 ("Plane", (center, dir, dim1, dim2)), Box, Face="Build"
             )
             id, exist = Surfaces.addPlane(plane)
@@ -1179,7 +1179,7 @@ def addConePlane(Definition, conesList, Surfaces, UniverseBox):
         ):
             continue
 
-        plane = GEOUNED_Surface(
+        plane = GeounedSurface(
             ("Plane", (cone.Surf.Apex, cone.Surf.Axis, 1, 1)), UniverseBox, Face="Build"
         )
         pid, exist = Surfaces.addPlane(plane)

--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -749,9 +749,9 @@ def cellDef(metaObj, Surfaces, UniverseBox):
         extraPlaneReverse = dict()
 
         flag_inv = isInverted(solid)
-        Solid_Gu = GU.SolidGu(solid)
+        solid_GU = GU.SolidGu(solid)
         lastTorus = -1
-        for iface, face in enumerate(Solid_Gu.Faces):
+        for iface, face in enumerate(solid_GU.Faces):
             surfaceType = str(face.Surface)
             if abs(face.Area) < tol.min_area:
                 if opt.verbose:
@@ -831,7 +831,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
 
                     idT = getId(face.Surface, Surfaces)
 
-                    index, Uparams = Solid_Gu.TorusUParams[iface]
+                    index, Uparams = solid_GU.TorusUParams[iface]
                     if index == lastTorus:
                         continue
                     lastTorus = index
@@ -880,7 +880,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                         VVar = "-%i" % idT
 
                     else:
-                        index, Vparams = Solid_Gu.TorusVParams[iface]
+                        index, Vparams = solid_GU.TorusVParams[iface]
                         VClosed, VminMax = Vparams
                         if VClosed:
                             VVar = "%i" % idT

--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -749,9 +749,9 @@ def cellDef(metaObj, Surfaces, UniverseBox):
         extraPlaneReverse = dict()
 
         flag_inv = isInverted(solid)
-        SolidGu = GU.SolidGu(solid)
+        Solid_Gu = GU.SolidGu(solid)
         lastTorus = -1
-        for iface, face in enumerate(SolidGu.Faces):
+        for iface, face in enumerate(Solid_Gu.Faces):
             surfaceType = str(face.Surface)
             if abs(face.Area) < tol.min_area:
                 if opt.verbose:
@@ -831,7 +831,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
 
                     idT = getId(face.Surface, Surfaces)
 
-                    index, Uparams = SolidGu.TorusUParams[iface]
+                    index, Uparams = Solid_Gu.TorusUParams[iface]
                     if index == lastTorus:
                         continue
                     lastTorus = index
@@ -880,7 +880,7 @@ def cellDef(metaObj, Surfaces, UniverseBox):
                         VVar = "-%i" % idT
 
                     else:
-                        index, Vparams = SolidGu.TorusVParams[iface]
+                        index, Vparams = Solid_Gu.TorusVParams[iface]
                         VClosed, VminMax = Vparams
                         if VClosed:
                             VVar = "%i" % idT

--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -115,7 +115,7 @@ def setDefinition(metaObj, Surfaces):
         solid_GU = GU.SolidGu(sol, plane3Pts=True)
 
         Faces = []
-        for face in SolidGu.Faces:
+        for face in Solid_Gu.Faces:
             if abs(face.Area) < 1e-2:
                 continue
             if face.Area < 0:

--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -115,7 +115,7 @@ def setDefinition(metaObj, Surfaces):
         solid_GU = GU.SolidGu(sol, plane3Pts=True)
 
         Faces = []
-        for face in solid_Gu.Faces:
+        for face in solid_GU.Faces:
             if abs(face.Area) < 1e-2:
                 continue
             if face.Area < 0:

--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -115,7 +115,7 @@ def setDefinition(metaObj, Surfaces):
         solid_GU = GU.SolidGu(sol, plane3Pts=True)
 
         Faces = []
-        for face in Solid_Gu.Faces:
+        for face in solid_Gu.Faces:
             if abs(face.Area) < 1e-2:
                 continue
             if face.Area < 0:

--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -112,10 +112,10 @@ def setDefinition(metaObj, Surfaces):
     for sol in solids:
         subSol = BoolSequence(operator="AND")
         flag_inv = isInverted(sol)
-        solid_GU = GU.solid_GU(sol, plane3Pts=True)
+        solid_GU = GU.SolidGu(sol, plane3Pts=True)
 
         Faces = []
-        for face in solid_GU.Faces:
+        for face in SolidGu.Faces:
             if abs(face.Area) < 1e-2:
                 continue
             if face.Area < 0:

--- a/src/geouned/GEOUNED/Decompose/Decom_one.py
+++ b/src/geouned/GEOUNED/Decompose/Decom_one.py
@@ -39,8 +39,8 @@ def splitFullCylinder(solid):
 
 
 def cutFullCylinder(solid):
-    solid_GU = GU.solid_GU(solid)
-    Surfaces = UF.Surfaces_dict()
+    solid_GU = GU.SolidGu(solid)
+    Surfaces = UF.SurfacesDict()
     flag_inv = CD.isInverted(solid_GU.solid)
     UniverseBox = solid.BoundBox
 
@@ -61,7 +61,7 @@ def cutFullCylinder(solid):
                 orig = face.Surface.Center
                 rad = face.Surface.Radius
                 dimL = face.ParameterRange[3] - face.ParameterRange[2]
-                cylinder = UF.GEOUNED_Surface(
+                cylinder = UF.GeounedSurface(
                     ("Cylinder", (orig, dir, rad, dimL)), UniverseBox
                 )
                 cylinder.buildSurface()
@@ -141,7 +141,7 @@ def CylBoundPlanes(face, boundBox):
             center = e.Curve.Center
             dim1 = e.Curve.Radius
             dim2 = e.Curve.Radius
-            plane = UF.GEOUNED_Surface(("Plane", (center, dir, dim1, dim2)), boundBox)
+            plane = UF.GeounedSurface(("Plane", (center, dir, dim1, dim2)), boundBox)
             planes.append(plane)
 
         elif curve == "<Ellipse object>":
@@ -149,7 +149,7 @@ def CylBoundPlanes(face, boundBox):
             center = e.Curve.Center
             dim1 = e.Curve.MinorRadius
             dim2 = e.Curve.MajorRadius
-            plane = UF.GEOUNED_Surface(("Plane", (center, dir, dim1, dim2)), boundBox)
+            plane = UF.GeounedSurface(("Plane", (center, dir, dim1, dim2)), boundBox)
             planes.append(plane)
 
     return planes
@@ -175,7 +175,7 @@ def TorusBoundPlanes(face, boundBox):
                 center = e.Curve.Center
                 dim1 = e.Curve.Radius
                 dim2 = e.Curve.Radius
-                plane = UF.GEOUNED_Surface(
+                plane = UF.GeounedSurface(
                     ("Plane", (center, dir, dim1, dim2)), boundBox
                 )
                 planes.append(plane)
@@ -185,13 +185,13 @@ def TorusBoundPlanes(face, boundBox):
             center = e.Curve.Center
             dim1 = e.Curve.MinorRadius
             dim2 = e.Curve.MajorRadius
-            plane = UF.GEOUNED_Surface(("Plane", (center, dir, dim1, dim2)), boundBox)
+            plane = UF.GeounedSurface(("Plane", (center, dir, dim1, dim2)), boundBox)
             planes.append(plane)
 
         elif curve == "<BSplineCurve object>":
             planeParams = PlaneSplineCurve(e)
             if planeParams is not None:
-                plane = UF.GEOUNED_Surface(("Plane", planeParams), boundBox)
+                plane = UF.GeounedSurface(("Plane", planeParams), boundBox)
                 planes.append(plane)
 
     return planes
@@ -220,16 +220,16 @@ def ExtractSurfaces(solid, kind, UniverseBox, MakeObj=False):
         fuzzy = True
         solidParts = []
         for s in solid.Solids:
-            solidParts.append(GU.solid_GU(s))
+            solidParts.append(GU.SolidGu(s))
     else:
         fuzzy = False
         if kind == "Plane3Pts":
             P3P = True
         else:
             P3P = False
-        solidParts = [GU.solid_GU(solid, P3P)]
+        solidParts = [GU.SolidGu(solid, P3P)]
 
-    Surfaces = UF.Surfaces_dict()
+    Surfaces = UF.SurfacesDict()
 
     for solid_GU in solidParts:
 
@@ -242,7 +242,7 @@ def ExtractSurfaces(solid, kind, UniverseBox, MakeObj=False):
                 pos = face.CenterOfMass
                 dim1 = face.ParameterRange[1] - face.ParameterRange[0]
                 dim2 = face.ParameterRange[3] - face.ParameterRange[2]
-                plane = UF.GEOUNED_Surface(
+                plane = UF.GeounedSurface(
                     ("Plane", (pos, normal, dim1, dim2)), UniverseBox
                 )
                 if MakeObj:
@@ -255,7 +255,7 @@ def ExtractSurfaces(solid, kind, UniverseBox, MakeObj=False):
                 rad = face.Surface.Radius
                 dimL = face.ParameterRange[3] - face.ParameterRange[2]
                 if kind in ["Cyl", "All"]:
-                    cylinder = UF.GEOUNED_Surface(
+                    cylinder = UF.GeounedSurface(
                         ("Cylinder", (orig, dir, rad, dimL)), UniverseBox
                     )
                     if MakeObj:
@@ -276,7 +276,7 @@ def ExtractSurfaces(solid, kind, UniverseBox, MakeObj=False):
                 dimL = face.ParameterRange[3] - face.ParameterRange[2]
                 dimR = face.Surface.Radius
                 if kind in ["Cone", "All"]:
-                    cone = UF.GEOUNED_Surface(
+                    cone = UF.GeounedSurface(
                         ("Cone", (apex, dir, halfAngle, dimL, dimR)), UniverseBox
                     )
                     if MakeObj:
@@ -292,7 +292,7 @@ def ExtractSurfaces(solid, kind, UniverseBox, MakeObj=False):
             elif surf[0:6] == "Sphere" and kind in ["Sph", "All"]:
                 rad = face.Surface.Radius
                 pnt = face.Surface.Center
-                sphere = UF.GEOUNED_Surface(("Sphere", (pnt, rad)), UniverseBox)
+                sphere = UF.GeounedSurface(("Sphere", (pnt, rad)), UniverseBox)
                 if MakeObj:
                     sphere.buildSurface()
                 Surfaces.addSphere(sphere)
@@ -309,7 +309,7 @@ def ExtractSurfaces(solid, kind, UniverseBox, MakeObj=False):
                     radMin = face.Surface.MinorRadius
                     center = face.Surface.Center
                     dir = face.Surface.Axis
-                    torus = UF.GEOUNED_Surface(
+                    torus = UF.GeounedSurface(
                         ("Torus", (center, dir, radMaj, radMin)), UniverseBox
                     )
                     if MakeObj:
@@ -329,7 +329,7 @@ def ExtractSurfaces(solid, kind, UniverseBox, MakeObj=False):
                 dim2 = face.ParameterRange[3] - face.ParameterRange[2]
                 points = tuple(v.Point for v in face.Vertexes)
 
-                plane = UF.GEOUNED_Surface(
+                plane = UF.GeounedSurface(
                     ("Plane3Pts", (pos, normal, dim1, dim2, points)), UniverseBox
                 )
                 if MakeObj:
@@ -810,7 +810,7 @@ def SplitPlanes_org(Solids, UniverseBox):
     return simpleSolid, err
 
 
-class parallelPlanes:
+class ParallelPlanes:
     def __init__(self, plane):
         self.Axis = plane.Surf.Axis
         self.elements = [plane]
@@ -840,7 +840,7 @@ class parallelPlanes:
 def sortPlanes(PlaneList, sortElements=False):
     if not PlaneList:
         return []
-    newList = [parallelPlanes(PlaneList[0])]
+    newList = [ParallelPlanes(PlaneList[0])]
     for p in PlaneList[1:]:
         found = False
         for pp in newList:
@@ -848,7 +848,7 @@ def sortPlanes(PlaneList, sortElements=False):
                 found = True
                 break
         if not found:
-            newList.append(parallelPlanes(p))
+            newList.append(ParallelPlanes(p))
 
     lenList = []
     for i, pp in enumerate(newList):
@@ -976,7 +976,7 @@ def split2ndOPlane(solid):
 
     err = 0
     flag_inv = CD.isInverted(solid)
-    solid_GU = GU.solid_GU(solid)
+    solid_GU = GU.SolidGu(solid)
     planes = Plane2ndOrder(solid_GU, None, flag_inv, convex=True)
     if not planes:
         return [solid], err

--- a/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
@@ -2,7 +2,7 @@ import re
 
 import FreeCAD
 
-from ..Utils.Functions import GEOUNED_Solid
+from ..Utils.Functions import GeounedSolid
 from ..Utils.Options.Classes import Options as opt
 
 
@@ -62,7 +62,7 @@ def fuseMetaObj(MetaList, init, end):
     for m in MetaList[init:end]:
         solids.extend(m.Solids)
 
-    newMeta = GEOUNED_Solid(init + 1, solids)
+    newMeta = GeounedSolid(init + 1, solids)
     newMeta.EnclosureID = MetaList[init].EnclosureID
     newMeta.ParentEnclosureID = MetaList[init].ParentEnclosureID
     newMeta.IsEnclosure = MetaList[init].IsEnclosure

--- a/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
@@ -51,7 +51,7 @@ def LoadCAD(filename, matfilename, defaultMat=[], compSolids=True):
     Solids = s.Solids
     MetaList = []
     for i, s in enumerate(Solids):
-        MetaList.append(UF.GEOUNED_Solid(i + 1, s))
+        MetaList.append(UF.GeounedSolid(i + 1, s))
 
     isolid = 0
     missingMat = set()

--- a/src/geouned/GEOUNED/Utils/BooleanSolids.py
+++ b/src/geouned/GEOUNED/Utils/BooleanSolids.py
@@ -7,7 +7,7 @@ import math
 import FreeCAD
 
 from ..Utils.booleanFunction import BoolSequence
-from ..Utils.Functions import GEOUNED_Surface, splitBOP
+from ..Utils.Functions import GeounedSurface, splitBOP
 from ..Utils.Options.Classes import Options as opt
 
 BoolVals = (None, True, False)
@@ -250,7 +250,7 @@ def buildCTableFromSolids(Box, SurfInfo, option="diag"):
         surfaces = SurfInfo.Surfaces
         surfaceList = SurfInfo.surfaceList
 
-    if type(surfaces[surfaceList[0]]) is GEOUNED_Surface:
+    if type(surfaces[surfaceList[0]]) is GeounedSurface:
         for s in surfaceList:
             ss = surfaces[s]
             ss.__boundBox__ = Box.BoundBox

--- a/src/geouned/GEOUNED/Utils/Functions.py
+++ b/src/geouned/GEOUNED/Utils/Functions.py
@@ -80,7 +80,7 @@ def makePlane(Plane, Boxin):
     return Part.Face(Part.makePolygon([pointEdge[p[1]] for p in orden], True))
 
 
-class GEOUNED_Solid:
+class GeounedSolid:
 
     def __init__(self, id, comsolid=None):
         refine = True
@@ -226,7 +226,7 @@ class GEOUNED_Solid:
             return 0
 
 
-class GEOUNED_Surface:
+class GeounedSurface:
 
     def __init__(self, params, boundBox, Face=None):
 
@@ -373,7 +373,7 @@ class GEOUNED_Surface:
             return
 
 
-class Surfaces_dict(dict):
+class SurfacesDict(dict):
     def __init__(self, surfaces=None, offset=0):
         self.IndexOffset = offset
         surfname = ["PX", "PY", "PZ", "P", "Cyl", "Cone", "Sph", "Tor"]

--- a/src/geouned/GEOUNED/Utils/Geometry_GU.py
+++ b/src/geouned/GEOUNED/Utils/Geometry_GU.py
@@ -11,7 +11,7 @@ from .BasicFunctions_part2 import isSameTorus
 
 
 # SURFACES
-class Surfaces_GU(object):
+class SurfacesGu(object):
 
     def __init__(self, face):
 
@@ -25,11 +25,11 @@ class Surfaces_GU(object):
         return self.type
 
 
-class Plane_GU(Surfaces_GU):
+class PlaneGu(SurfacesGu):
 
     def __init__(self, face, plane3Pts=False):
 
-        Surfaces_GU.__init__(self, face)
+        SurfacesGu.__init__(self, face)
         self.Axis = face.Surface.Axis
         self.Position = face.Surface.Position
         self.pointDef = plane3Pts
@@ -45,22 +45,22 @@ class Plane_GU(Surfaces_GU):
             self.dim2 = face.ParameterRange[3] - face.ParameterRange[2]
 
 
-class Cylinder_GU(Surfaces_GU):
+class CylinderGu(SurfacesGu):
 
     def __init__(self, face):
 
-        Surfaces_GU.__init__(self, face)
+        SurfacesGu.__init__(self, face)
         self.Axis = face.Surface.Axis
         self.Radius = face.Surface.Radius
         self.Center = face.Surface.Center
         self.dimL = face.ParameterRange[3] - face.ParameterRange[2]
 
 
-class Cone_GU(Surfaces_GU):
+class ConeGu(SurfacesGu):
 
     def __init__(self, face):
 
-        Surfaces_GU.__init__(self, face)
+        SurfacesGu.__init__(self, face)
         self.Axis = face.Surface.Axis
         self.Apex = face.Surface.Apex
         self.SemiAngle = face.Surface.SemiAngle
@@ -69,28 +69,28 @@ class Cone_GU(Surfaces_GU):
         self.Radius = face.Surface.Radius
 
 
-class Sphere_GU(Surfaces_GU):
+class SphereGu(SurfacesGu):
 
     def __init__(self, face):
 
-        Surfaces_GU.__init__(self, face)
+        SurfacesGu.__init__(self, face)
         self.type = self.type[0:6]
         self.Center = face.Surface.Center
         self.Radius = face.Surface.Radius
 
 
-class Torus_GU(Surfaces_GU):
+class TorusGu(SurfacesGu):
 
     def __init__(self, face):
 
-        Surfaces_GU.__init__(self, face)
+        SurfacesGu.__init__(self, face)
         self.Center = face.Surface.Center
         self.Axis = face.Surface.Axis
         self.MajorRadius = face.Surface.MajorRadius
         self.MinorRadius = face.Surface.MinorRadius
 
 
-class solid_GU:
+class SolidGu:
 
     def __init__(self, solid, plane3Pts=False):
         self.solid = solid
@@ -225,7 +225,7 @@ class solid_GU:
 
 
 # FACES
-class Faces_GU(object):
+class FaceGu(object):
     def __init__(self, face, Plane3Pts=False):
         # GEOUNED based atributes
         self.__face__ = face
@@ -277,21 +277,21 @@ class Faces_GU(object):
 # Aux functions
 def DefineListFace_GU(face_list, plane3Pts=False):
     """Return the list of the  corresponding Face_GU  object of a FaceList"""
-    return tuple(Faces_GU(face, plane3Pts) for face in face_list)
+    return tuple(FaceGu(face, plane3Pts) for face in face_list)
 
 
 def DefineSurface(face, plane3Pts):
     kind_surf = str(face.Surface)
     if kind_surf == "<Plane object>":
-        Surf_GU = Plane_GU(face, plane3Pts)
+        Surf_GU = PlaneGu(face, plane3Pts)
     elif kind_surf == "<Cylinder object>":
-        Surf_GU = Cylinder_GU(face)
+        Surf_GU = CylinderGu(face)
     elif kind_surf == "<Cone object>":
-        Surf_GU = Cone_GU(face)
+        Surf_GU = ConeGu(face)
     elif kind_surf[0:6] == "Sphere":
-        Surf_GU = Sphere_GU(face)
+        Surf_GU = SphereGu(face)
     elif kind_surf == "<Toroid object>":
-        Surf_GU = Torus_GU(face)
+        Surf_GU = TorusGu(face)
     else:
         print("bad Surface type", kind_surf)
         Surf_GU = None

--- a/src/geouned/GEOUNED/Utils/Options/Classes.py
+++ b/src/geouned/GEOUNED/Utils/Options/Classes.py
@@ -2,7 +2,7 @@ class Options:
     pass
 
 
-class MCNP_numeric_format:
+class McnpNumericFormat:
     pass
 
 

--- a/src/geouned/GEOUNED/Utils/Options/__init__.py
+++ b/src/geouned/GEOUNED/Utils/Options/__init__.py
@@ -1,4 +1,4 @@
-from .Classes import MCNP_numeric_format, Options, Tolerances
+from .Classes import McnpNumericFormat, Options, Tolerances
 
 # default options values
 forceCylinder = True  # Force using cylinders instead cones for auxillary surfaces of torus surface definition
@@ -74,4 +74,4 @@ for key in tolValueDict.keys():
 
 # Set default  attributes to MCNP number format class
 for key in numValueDict.keys():
-    setattr(MCNP_numeric_format, key, numValueDict[key])
+    setattr(McnpNumericFormat, key, numValueDict[key])

--- a/src/geouned/GEOUNED/Void/Void.py
+++ b/src/geouned/GEOUNED/Void/Void.py
@@ -4,7 +4,7 @@ import Part
 from ..LoadFile import LoadFunctions as LF
 from ..Utils.BasicFunctions_part1 import isOposite
 from ..Utils.booleanFunction import BoolSequence
-from ..Utils.Functions import GEOUNED_Solid, GEOUNED_Surface
+from ..Utils.Functions import GeounedSolid, GeounedSurface
 from ..Utils.Options.Classes import Options as opt
 from ..Void import voidFunctions as VF
 from .VoidBoxClass import VoidBox
@@ -31,7 +31,7 @@ def voidGeneration(MetaList, EnclosureList, Surfaces, UniverseBox, setting, init
         FreeCAD.Vector(0, 0, 1),
     )
 
-    EnclosureBox = GEOUNED_Solid(None, Box)
+    EnclosureBox = GeounedSolid(None, Box)
     if setting["voidMat"]:
         voidMat = setting["voidMat"]
         EnclosureBox.setMaterial(voidMat[0], voidMat[1], voidMat[2])
@@ -128,7 +128,7 @@ def GetVoidDef(MetaList, Surfaces, Enclosure, setting, Lev0=False):
 
     voidList = []
     for i, vcell in enumerate(VoidDef):
-        mVoid = GEOUNED_Solid(i)
+        mVoid = GeounedSolid(i)
         mVoid.Void = True
         mVoid.CellType = "void"
         mVoid.setDefinition(vcell[0], simplify=True)
@@ -148,7 +148,7 @@ def setGraveyardCell(Surfaces, UniverseBox):
     externalBox = getUniverseComplementary(Universe, Surfaces)
     center = UniverseBox.Center
     radius = 0.51 * UniverseBox.DiagonalLength
-    sphere = GEOUNED_Surface(("Sphere", (center, radius)), UniverseBox)
+    sphere = GeounedSurface(("Sphere", (center, radius)), UniverseBox)
     id, exist = Surfaces.addSphere(sphere)
 
     sphdef = BoolSequence(str(-id))
@@ -157,14 +157,14 @@ def setGraveyardCell(Surfaces, UniverseBox):
 
     notsph = BoolSequence(str(id))
 
-    mVoidSphIn = GEOUNED_Solid(0)
+    mVoidSphIn = GeounedSolid(0)
     mVoidSphIn.Void = True
     mVoidSphIn.CellType = "void"
     mVoidSphIn.setDefinition(sphdef)
     mVoidSphIn.setMaterial(0, 0, "Graveyard_in")
     mVoidSphIn.__commentInfo__ = None
 
-    mVoidSphOut = GEOUNED_Solid(1)
+    mVoidSphOut = GeounedSolid(1)
     mVoidSphOut.Void = True
     mVoidSphOut.CellType = "void"
     mVoidSphOut.setDefinition(notsph)

--- a/src/geouned/GEOUNED/Void/VoidBoxClass.py
+++ b/src/geouned/GEOUNED/Void/VoidBoxClass.py
@@ -8,7 +8,7 @@ from ..Decompose import Decom_one as Decom
 from ..Utils.BasicFunctions_part1 import isOposite
 from ..Utils.booleanFunction import BoolSequence
 from ..Utils.BooleanSolids import buildCTableFromSolids, removeExtraSurfaces
-from ..Utils.Functions import GEOUNED_Solid, GEOUNED_Surface
+from ..Utils.Functions import GeounedSolid, GeounedSurface
 from ..Utils.Options.Classes import Options as opt
 
 
@@ -181,7 +181,7 @@ class VoidBox:
 
         else:
             UniverseBox = self.PieceEnclosure.BoundBox
-            TempPieceEnclosure = GEOUNED_Solid(None, self.PieceEnclosure)
+            TempPieceEnclosure = GeounedSolid(None, self.PieceEnclosure)
             comsolid, err = Decom.SplitSolid(
                 Part.makeCompound(TempPieceEnclosure.Solids), UniverseBox
             )
@@ -354,7 +354,7 @@ class VoidBox:
         LX = self.BoundBox.ZMin + self.BoundBox.XLength
         LY = self.BoundBox.ZMin + self.BoundBox.YLength
         LZ = self.BoundBox.ZMin + self.BoundBox.ZLength
-        PXMin = GEOUNED_Surface(
+        PXMin = GeounedSurface(
             (
                 "Plane",
                 (
@@ -366,7 +366,7 @@ class VoidBox:
             ),
             self.BoundBox,
         )
-        PXMax = GEOUNED_Surface(
+        PXMax = GeounedSurface(
             (
                 "Plane",
                 (
@@ -378,7 +378,7 @@ class VoidBox:
             ),
             self.BoundBox,
         )
-        PYMin = GEOUNED_Surface(
+        PYMin = GeounedSurface(
             (
                 "Plane",
                 (
@@ -390,7 +390,7 @@ class VoidBox:
             ),
             self.BoundBox,
         )
-        PYMax = GEOUNED_Surface(
+        PYMax = GeounedSurface(
             (
                 "Plane",
                 (
@@ -402,7 +402,7 @@ class VoidBox:
             ),
             self.BoundBox,
         )
-        PZMin = GEOUNED_Surface(
+        PZMin = GeounedSurface(
             (
                 "Plane",
                 (
@@ -414,7 +414,7 @@ class VoidBox:
             ),
             self.BoundBox,
         )
-        PZMax = GEOUNED_Surface(
+        PZMax = GeounedSurface(
             (
                 "Plane",
                 (
@@ -458,7 +458,7 @@ class VoidBox:
     def __copyMeta__(self, m):
         solidsCopy = m.Solids[:]
         facesCopy = m.Faces[:]
-        Meta = GEOUNED_Solid(m.__id__, solidsCopy)
+        Meta = GeounedSolid(m.__id__, solidsCopy)
         Meta.setDefinition(m.Definition.copy())
         Meta.setFaces(facesCopy)
         if m.IsEnclosure:

--- a/src/geouned/GEOUNED/Write/Functions.py
+++ b/src/geouned/GEOUNED/Write/Functions.py
@@ -5,7 +5,7 @@ import FreeCAD
 
 from ..Utils import Qform as Qform
 from ..Utils.BasicFunctions_part1 import isOposite, isParallel
-from ..Utils.Options.Classes import MCNP_numeric_format as nf
+from ..Utils.Options.Classes import McnpNumericFormat as nf
 from ..Utils.Options.Classes import Options as opt
 from ..Utils.Options.Classes import Tolerances as tol
 from .StringFunctions import remove_redundant

--- a/src/geouned/GEOUNED/Write/MCNPFormat.py
+++ b/src/geouned/GEOUNED/Write/MCNPFormat.py
@@ -8,12 +8,12 @@ import FreeCAD
 
 from ..CodeVersion import *
 from ..Utils.BasicFunctions_part1 import isOposite, pointsToCoeffs
-from ..Utils.Functions import Surfaces_dict
+from ..Utils.Functions import SurfacesDict
 from ..Utils.Options.Classes import Options as opt
 from .Functions import CardLine, MCNPSurface, changeSurfSign, writeMCNPCellDef
 
 
-class MCNP_input:
+class McnpInput:
     def __init__(self, Meta, Surfaces, setting):
         self.Title = setting["title"]
         self.VolSDEF = setting["volSDEF"]
@@ -326,7 +326,7 @@ C **************************************************************\n""".format(
         return
 
     def __sortedSurfaces__(self, Surfaces):
-        temp = Surfaces_dict(Surfaces)
+        temp = SurfacesDict(Surfaces)
         surfList = []
         for ind in range(
             Surfaces.IndexOffset, Surfaces.surfaceNumber + Surfaces.IndexOffset

--- a/src/geouned/GEOUNED/Write/OpenMCFormat.py
+++ b/src/geouned/GEOUNED/Write/OpenMCFormat.py
@@ -5,12 +5,12 @@
 import FreeCAD
 
 from ..CodeVersion import *
-from ..Utils.Functions import Surfaces_dict
+from ..Utils.Functions import SurfacesDict
 from ..Utils.Options.Classes import Options as opt
 from .Functions import OpenMCSurface, changeSurfSign, writeOpenMCregion
 
 
-class OpenMC_input:
+class OpenmcInput:
     def __init__(self, Meta, Surfaces, setting):
 
         self.Cells = Meta
@@ -243,7 +243,7 @@ import openmc
         return
 
     def __sortedSurfaces__(self, Surfaces):
-        temp = Surfaces_dict(Surfaces)
+        temp = SurfacesDict(Surfaces)
         surfList = []
         for ind in range(
             Surfaces.IndexOffset, Surfaces.surfaceNumber + Surfaces.IndexOffset

--- a/src/geouned/GEOUNED/Write/PHITSFormat.py
+++ b/src/geouned/GEOUNED/Write/PHITSFormat.py
@@ -18,7 +18,7 @@ import FreeCAD
 
 from ..CodeVersion import *
 from ..Utils.BasicFunctions_part1 import isOposite, pointsToCoeffs
-from ..Utils.Functions import Surfaces_dict
+from ..Utils.Functions import SurfacesDict
 from ..Utils.Options.Classes import Options as opt
 from ..Write.Functions import (
     CellString,
@@ -28,7 +28,7 @@ from ..Write.Functions import (
 )
 
 
-class PHITS_input:
+class PhitsInput:
     def __init__(self, Meta, Surfaces, setting):
         self.Title = setting["title"]
         self.VolSDEF = setting["volSDEF"]
@@ -576,7 +576,7 @@ $ **************************************************************
         return
 
     def __sortedSurfaces__(self, Surfaces):
-        temp = Surfaces_dict(Surfaces)
+        temp = SurfacesDict(Surfaces)
         surfList = []
         for ind in range(
             Surfaces.IndexOffset, Surfaces.surfaceNumber + Surfaces.IndexOffset

--- a/src/geouned/GEOUNED/Write/SerpentFormat.py
+++ b/src/geouned/GEOUNED/Write/SerpentFormat.py
@@ -7,12 +7,12 @@ import FreeCAD
 
 from ..CodeVersion import *
 from ..Utils.BasicFunctions_part1 import isOposite, pointsToCoeffs
-from ..Utils.Functions import Surfaces_dict
+from ..Utils.Functions import SurfacesDict
 from ..Utils.Options.Classes import Options as opt
 from .Functions import SerpentSurface, changeSurfSign, writeSerpentCellDef
 
 
-class Serpent_input:
+class SerpentInput:
     def __init__(self, Meta, Surfaces, setting):
         self.Title = setting["title"]
         self.VolSDEF = setting["volSDEF"]
@@ -335,7 +335,7 @@ class Serpent_input:
         return
 
     def __sortedSurfaces__(self, Surfaces):
-        temp = Surfaces_dict(Surfaces)
+        temp = SurfacesDict(Surfaces)
         surfList = []
         for ind in range(
             Surfaces.IndexOffset, Surfaces.surfaceNumber + Surfaces.IndexOffset

--- a/src/geouned/GEOUNED/Write/WriteFiles.py
+++ b/src/geouned/GEOUNED/Write/WriteFiles.py
@@ -1,8 +1,8 @@
 from . import AdditionalFiles as OutFiles
-from .MCNPFormat import MCNP_input
-from .OpenMCFormat import OpenMC_input
-from .PHITSFormat import PHITS_input
-from .SerpentFormat import Serpent_input
+from .MCNPFormat import McnpInput
+from .OpenMCFormat import OpenmcInput
+from .PHITSFormat import PhitsInput
+from .SerpentFormat import SerpentInput
 
 
 def writeGeometry(UniverseBox, MetaList, Surfaces, code_setting):
@@ -30,7 +30,7 @@ def writeGeometry(UniverseBox, MetaList, Surfaces, code_setting):
         else:
             outSphere = None
 
-        MCNPfile = MCNP_input(MetaList, Surfaces, code_setting)
+        MCNPfile = McnpInput(MetaList, Surfaces, code_setting)
         MCNPfile.setSDEF((outSphere, outBox))
         MCNPfile.writeInput(mcnpFilename)
 
@@ -38,7 +38,7 @@ def writeGeometry(UniverseBox, MetaList, Surfaces, code_setting):
         "openMC_XML" in code_setting["outFormat"]
         or "openMC_PY" in code_setting["outFormat"]
     ):
-        OMCFile = OpenMC_input(MetaList, Surfaces, code_setting)
+        OMCFile = OpenmcInput(MetaList, Surfaces, code_setting)
 
     if "openMC_XML" in code_setting["outFormat"]:
         omcFilename = baseName + ".xml"
@@ -63,7 +63,7 @@ def writeGeometry(UniverseBox, MetaList, Surfaces, code_setting):
         else:
             outSphere = None
 
-        Serpentfile = Serpent_input(MetaList, Surfaces, code_setting)
+        Serpentfile = SerpentInput(MetaList, Surfaces, code_setting)
         # Serpentfile.setSDEF((outSphere,outBox))
         Serpentfile.writeInput(serpentFilename)
 
@@ -85,6 +85,6 @@ def writeGeometry(UniverseBox, MetaList, Surfaces, code_setting):
         else:
             PHITS_outSphere = None
 
-        PHITSfile = PHITS_input(MetaList, Surfaces, code_setting)
+        PHITSfile = PhitsInput(MetaList, Surfaces, code_setting)
         # PHITSfile.setSDEF_PHITS((PHITS_outSphere,PHITS_outBox))
         PHITSfile.writePHITS(phitsFilename)

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -3,14 +3,6 @@
 
 # We load the STEP and the materials
 
-# this try except attempts to import freecad (lowercase) which is the conda
-# package name for FreeCAD (mixed case) upon import the conda package appends
-# the sys path for Conda installed FreeCAD, consequently FreeCAD can then be
-# found by subsequent import statements through out the code base
-try:
-    import freecad
-except:
-    pass
 import configparser
 import typing
 from datetime import datetime
@@ -26,13 +18,13 @@ from .Decompose import Decom_one as Decom
 from .LoadFile import LoadSTEP as Load
 from .Utils import Functions as UF
 from .Utils.BooleanSolids import buildCTableFromSolids
-from .Utils.Options.Classes import MCNP_numeric_format, Options, Tolerances
+from .Utils.Options.Classes import McnpNumericFormat, Options, Tolerances
 from .Void import Void as Void
 from .Write.Functions import writeMCNPCellDef
 from .Write.WriteFiles import writeGeometry
 
 
-class GEOUNED:
+class CadToCsg:
 
     def __init__(
         self,
@@ -316,7 +308,7 @@ class GEOUNED:
                 for key in config["MCNP_Numeric_Format"].keys():
                     if key in numericKwrd:
                         setattr(
-                            MCNP_numeric_format,
+                            McnpNumericFormat,
                             key,
                             config.get("MCNP_Numeric_Format", key),
                         )
@@ -330,7 +322,7 @@ class GEOUNED:
             self.__dict__["geometryName"] = self.__dict__["stepFile"][:-4]
 
         if Options.prnt3PPlane and not PdEntry:
-            MCNP_numeric_format.P_d = "22.15e"
+            McnpNumericFormat.P_d = "22.15e"
 
         print(self.__dict__)
 
@@ -470,7 +462,7 @@ class GEOUNED:
         else:
             UniverseBox = getUniverse(MetaList)
 
-        Surfaces = UF.Surfaces_dict(offset=self.startSurf - 1)
+        Surfaces = UF.SurfacesDict(offset=self.startSurf - 1)
 
         warnSolids = []
         warnEnclosures = []
@@ -606,7 +598,7 @@ class GEOUNED:
 ##########################################################
              VOID CELLS
 ##########################################################"""
-            mc = UF.GEOUNED_Solid(None)
+            mc = UF.GeounedSolid(None)
             mc.Comments = lineComment
             MetaList.append(mc)
 
@@ -822,7 +814,7 @@ def sortEnclosure(MetaList, MetaVoid, offSet=0):
 ##########################################################""".format(
                 m.EnclosureID
             )
-            mc = UF.GEOUNED_Solid(None)
+            mc = UF.GeounedSolid(None)
             mc.Comments = lineComment
             newMeta.append(mc)
             for e in newList[m.EnclosureID]:
@@ -838,7 +830,7 @@ def sortEnclosure(MetaList, MetaVoid, offSet=0):
 ##########################################################""".format(
                 m.EnclosureID
             )
-            mc = UF.GEOUNED_Solid(None)
+            mc = UF.GeounedSolid(None)
             mc.Comments = lineComment
             newMeta.append(mc)
 
@@ -852,7 +844,7 @@ def sortEnclosure(MetaList, MetaVoid, offSet=0):
 ##########################################################
              VOID CELLS 
 ##########################################################"""
-    mc = UF.GEOUNED_Solid(None)
+    mc = UF.GeounedSolid(None)
     mc.Comments = lineComment
     newMeta.append(mc)
 

--- a/testing/test.py
+++ b/testing/test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parents[1] / "src"))
 sys.path.append("/usr/lib64/freecad/lib64/")
 
-from geouned import GEOUNED
+from geouned import CadToCsg
 
 
 def setInput(inName, inpDir, outDir):
@@ -157,7 +157,7 @@ def printResults(f, res, lost):
 def mkGEOInp(inpDir, outDir):
     for f in getInputList(inpDir, ("stp", "step")):
         setInput(f, inpDir, outDir)
-        GEO = GEOUNED(inifile)
+        GEO = CadToCsg(inifile)
         GEO.SetOptions()
         GEO.Start()
         del GEO

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from geouned import GEOUNED
+from geouned import CadToCsg
 
 path_to_cad = Path("testing/inputSTEP")
 step_files = list(path_to_cad.rglob("*.stp")) + list(path_to_cad.rglob("*.step"))
@@ -50,7 +50,7 @@ def test_conversion(input_step_file):
     output_filename_stem.with_suffix(".xml").unlink(missing_ok=True)
 
     inifile = f"{output_dir/'config.ini'}"
-    GEO = GEOUNED(inifile)
+    GEO = CadToCsg(inifile)
     GEO.SetOptions()
     GEO.outFormat = ("mcnp", "openMC_XML")
     GEO.Start()


### PR DESCRIPTION
I've renamed all the classes so that they are in CamelCase as recommended by PEP8. I think this will make the package more natural to python users as CamelCase is the convention

While rename the user facing GEOUNED class I also changed this to CadToCsg as I think this describes the functionally a bit better. Happy to role back that change if people prefer

Apologies but I snuck in a couple more tiny changes

Also updated the licence line in the pyproject.tom to the current license
Also was able to remove two of the try: import freecad parts as we now have it in the main package __init__ so don't need it in the GEOUNED __init__ or GEOReverse __init__