### PR TITLE
Fix to position of additional cylindrical surface used to limit torus extent

### DIFF
--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -697,11 +697,13 @@ def GenTorusAnnexVSurface(face, Vparams, forceCylinder=False):
             pMid = face.valueAt(0, Vmid) - center
             if pMid.cross(axis).Length < face.Surface.MajorRadius:
                 inSurf = True
+                radius = max(d1,d2)
             else:
                 inSurf = False
         else:
             if d1 < face.Surface.MajorRadius:
                 inSurf = True
+                radius = max(d1,d2)
             else:
                 inSurf = False
         return (center, axis, radius, face.Surface.MinorRadius), surfType, inSurf


### PR DESCRIPTION
This PR fixes #94. Instead of always using the minimum radius of d1 and d2, if the cell is inside of the surface it uses the maximum radius in order to ensure we do not clip the cell unnecessarily.