### PR TITLE
Using "is" instead of "==" to compare boolean values

### DIFF
--- a/src/geouned/GEOReverse/Modules/Utils/BooleanSolids.py
+++ b/src/geouned/GEOReverse/Modules/Utils/BooleanSolids.py
@@ -317,9 +317,9 @@ def removeExtraSurfaces(CellSeq, CTable):
         nullcell = False
         chk = subCell.check()
 
-        if chk == False:  # the cell doesn't exist
+        if chk is False:  # the cell doesn't exist
             nullcell = True
-        elif chk == True:  # the cell describe the full universe
+        elif chk is True:  # the cell describe the full universe
             newDef.elements = True
             newDef.level = 0
             return newDef
@@ -336,7 +336,7 @@ def removeExtraSurfaces(CellSeq, CTable):
                     val = True if CTable[s][s].val > 0 else False
                     subCell.substitute(s, val)
                 if type(subCell.elements) is bool:
-                    if subCell.elements == False:  #  cell does not intersect void box
+                    if subCell.elements is False:  #  cell does not intersect void box
                         continue
                     else:  # cell cover fully void box
                         newDef.elements = True
@@ -345,7 +345,7 @@ def removeExtraSurfaces(CellSeq, CTable):
                 else:
                     newDef.append(subCell)
 
-            elif res == True:
+            elif res is True:
                 # subcell cover the full box region Void cell doesn't exist
                 newDef.elements = True
                 newDef.level = 0

--- a/src/geouned/GEOReverse/Modules/Utils/booleanFunction.py
+++ b/src/geouned/GEOReverse/Modules/Utils/booleanFunction.py
@@ -41,9 +41,9 @@ class BoolSequence:
                 if type(s.elements) is bool:
                     if (
                         self.operator == "AND"
-                        and s.elements == False
+                        and s.elements is False
                         or self.operator == "OR"
-                        and s.elements == True
+                        and s.elements is True
                     ):
                         self.level = 0
                         self.elements = s.elements
@@ -144,9 +144,9 @@ class BoolSequence:
                 if type(e.elements) is bool:
                     if (
                         self.operator == "AND"
-                        and e.elements == False
+                        and e.elements is False
                         or self.operator == "OR"
-                        and e.elements == True
+                        and e.elements is True
                     ):
                         self.elements = e.elements
                         self.level = 0
@@ -186,9 +186,9 @@ class BoolSequence:
                 res = e.check()
                 if res is None:
                     noneVal = True
-                elif self.operator == "AND" and res == False:
+                elif self.operator == "AND" and res is False:
                     return False
-                elif self.operator == "OR" and res == True:
+                elif self.operator == "OR" and res is True:
                     return True
 
             if noneVal:
@@ -344,7 +344,7 @@ class BoolSequence:
             return True
 
         funcVal = self.evaluate(trueSet, CT)
-        if funcVal == False:
+        if funcVal is False:
             newSeq = BoolSequence(operator="AND")
             # self.substitute(valname,False)
             for name, value in falseSet.items():
@@ -352,7 +352,7 @@ class BoolSequence:
             newSeq.append(-valname, self.copy())
             self.assign(newSeq)
             return True
-        elif funcVal == True:
+        elif funcVal is True:
             newSeq = BoolSequence(operator="OR")
             # self.substitute(valname,False)
             for name, value in falseSet.items():
@@ -362,7 +362,7 @@ class BoolSequence:
             return True
 
         funcVal = self.evaluate(falseSet, CT)
-        if funcVal == False:
+        if funcVal is False:
             newSeq = BoolSequence(operator="AND")
             # self.substitute(valname,True)
             for name, value in trueSet.items():
@@ -370,7 +370,7 @@ class BoolSequence:
             newSeq.append(valname, self.copy())
             self.assign(newSeq)
             return True
-        elif funcVal == True:
+        elif funcVal is True:
             newSeq = BoolSequence(operator="OR")
             # self.substitute(valname,True)
             for name, value in trueSet.items():
@@ -444,9 +444,9 @@ class BoolSequence:
 
             if val is None:
                 noneVal = True
-            elif op == "AND" and val == False:
+            elif op == "AND" and val is False:
                 return False
-            elif op == "OR" and val == True:
+            elif op == "OR" and val is True:
                 return True
 
         if noneVal:

--- a/src/geouned/GEOUNED/Utils/BooleanSolids.py
+++ b/src/geouned/GEOUNED/Utils/BooleanSolids.py
@@ -337,9 +337,9 @@ def removeExtraSurfaces(CellSeq, CTable):
         else:
             chk = None
 
-        if chk == False:  # the cell doesn't exist
+        if chk is False:  # the cell doesn't exist
             nullcell = True
-        elif chk == True:  # the cell describe the full universe
+        elif chk is True:  # the cell describe the full universe
             newDef.elements = True
             newDef.level = -1
             return newDef
@@ -360,7 +360,7 @@ def removeExtraSurfaces(CellSeq, CTable):
                         subCell.substitute(s, val)
 
                 if type(subCell.elements) is bool:
-                    if subCell.elements == False:  #  cell does not intersect void box
+                    if subCell.elements is False:  #  cell does not intersect void box
                         continue
                     else:  # cell cover fully void box
                         newDef.elements = True
@@ -369,7 +369,7 @@ def removeExtraSurfaces(CellSeq, CTable):
                 else:
                     newDef.append(subCell)
 
-            elif res == True:
+            elif res is True:
                 # subcell cover the full box region Void cell doesn't exist
                 newDef.elements = True
                 newDef.level = -1

--- a/src/geouned/GEOUNED/Utils/booleanFunction.py
+++ b/src/geouned/GEOUNED/Utils/booleanFunction.py
@@ -468,11 +468,11 @@ class BoolSequence:
 
         falseFunc = subSeq.evaluate(falseSet)
 
-        if trueFunc == False:
+        if trueFunc is False:
             newSeq = BoolSequence(operator="AND")
-            if falseFunc == True:
+            if falseFunc is True:
                 newSeq.append(-valname)
-            elif falseFunc == False:
+            elif falseFunc is False:
                 newSeq.elements = False
                 newSeq.level = -1
             else:
@@ -485,12 +485,12 @@ class BoolSequence:
                 self.assign(newSeq)
             return True
 
-        elif trueFunc == True:
+        elif trueFunc is True:
             newSeq = BoolSequence(operator="OR")
-            if falseFunc == True:
+            if falseFunc is True:
                 newSeq.elements = True
                 newSeq.level = -1
-            elif falseFunc == False:
+            elif falseFunc is False:
                 newSeq.append(valname)
             else:
                 newSeq.append(valname, falseFunc)
@@ -502,11 +502,11 @@ class BoolSequence:
                 self.assign(newSeq)
             return True
 
-        if falseFunc == False:
+        if falseFunc is False:
             newSeq = BoolSequence(operator="AND")
-            if trueFunc == True:
+            if trueFunc is True:
                 newSeq.append(valname)
-            elif trueFunc == False:
+            elif trueFunc is False:
                 newSeq.elements = False
                 newSeq.level = -1
             else:
@@ -518,12 +518,12 @@ class BoolSequence:
                 self.assign(newSeq)
             return True
 
-        elif falseFunc == True:
+        elif falseFunc is True:
             newSeq = BoolSequence(operator="OR")
-            if trueFunc == True:
+            if trueFunc is True:
                 newSeq.elements = True
                 newSeq.level = -1
-            elif trueFunc == False:
+            elif trueFunc is False:
                 newSeq.append(-valname)
             else:
                 newSeq.append(-valname, trueFunc)

--- a/src/geouned/GEOUNED/Void/VoidBoxClass.py
+++ b/src/geouned/GEOUNED/Void/VoidBoxClass.py
@@ -248,7 +248,7 @@ class VoidBox:
                     surfaceDict[i] = Surfaces.getSurface(i)
                 CTable = buildCTableFromSolids(Box, surfaceDict, option=simplify)
             else:
-                if res == True:
+                if res is True:
                     return None, None
                 else:
                     return boxDef, None
@@ -266,7 +266,7 @@ class VoidBox:
                 newSolid = removeExtraSurfaces(solDef, CTable)
                 if type(newSolid.elements) is not bool:
                     newTemp.append(newSolid)
-                elif newSolid.elements == True:
+                elif newSolid.elements is True:
                     return None, None
 
             voidSolidDef = newTemp
@@ -279,9 +279,9 @@ class VoidBox:
                 cellVoid.append(voidSolidDef)
                 voidSolidDef = cellVoid
 
-        if voidSolidDef.elements == True:
+        if voidSolidDef.elements is True:
             return None, None
-        elif voidSolidDef.elements == False or voidSolidDef.elements == []:
+        elif voidSolidDef.elements is False or voidSolidDef.elements == []:
             return boxDef, None
 
         if voidSolidDef.level == 0:
@@ -302,13 +302,13 @@ class VoidBox:
                         chk = None
 
                     # solid in cover full Void cell volume  => Void cell doesn't exist
-                    if chk == True:
+                    if chk is True:
                         if opt.verbose:
                             print("warning void Cell should not exist")
                         return None, None
 
                     # solid cell is not in void cell Void cell volume  => doesn't contribute to void definition
-                    elif chk == False:
+                    elif chk is False:
                         continue
 
                 pmoc = comp.getComplementary()


### PR DESCRIPTION
This PR changes all the cases in the code where we compare a boolean using "==" to use "is" instead

PEP8
    E712 comparison to False should be 'if cond is False:' or 'if not cond:'
    E712 comparison to True should be 'if cond is True:' or 'if cond:

this reduces the pep8 warnings identified by flake8 to 662, the dev branch is currently 700

To count flake8 warnings 
```
pip install flake8
cd GEOUNED  # cd to base repo folder
flake8 --count
```