### PR TITLE
Adding formatter to CI to keep code in PEP8

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,10 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable

--- a/scripts/geounedClassCall.py
+++ b/scripts/geounedClassCall.py
@@ -6,23 +6,21 @@
 # only if modules are not in the PYTHONPATH or directly installed in the python distribution used
 import sys
 
-geo_path="C:\\Users\\Patrick\\Documents\\GitHub\\GEOUNED\\src"
+geo_path = "C:\\Users\\Patrick\\Documents\\GitHub\\GEOUNED\\src"
 sys.path.append(geo_path)
-sys.path.append('C:\\Program Files\\FreeCAD 0.19\\bin...')
+sys.path.append("C:\\Program Files\\FreeCAD 0.19\\bin...")
 
 from geouned import CadToCsg
 
-stepFileName = 'placa.stp'
+stepFileName = "placa.stp"
 
-GEO = CadToCsg('Conversion Example')
+GEO = CadToCsg("Conversion Example")
 
-GEO.set('stepFile', stepFileName)
-GEO.set('geometryName','Placa')
-GEO.set('outFormat', ('mcnp', 'openMC_XML'))
-GEO.set('planeDistance', 0.05)
-GEO.set('quadricPY', True)
-GEO.set('P_abc', '12f')
-GEO.set('P_d', '12f')
+GEO.set("stepFile", stepFileName)
+GEO.set("geometryName", "Placa")
+GEO.set("outFormat", ("mcnp", "openMC_XML"))
+GEO.set("planeDistance", 0.05)
+GEO.set("quadricPY", True)
+GEO.set("P_abc", "12f")
+GEO.set("P_d", "12f")
 GEO.Start()
-
-      

--- a/src/geouned/GEOReverse/Modules/MCNPinput.py
+++ b/src/geouned/GEOReverse/Modules/MCNPinput.py
@@ -175,6 +175,7 @@ class McnpInput:
                 trl[c.name] = getTransMatrix(trValues, c.unit)
         return trl
 
+
 # fmt: off
 def getTransMatrix(trsf, unit="", scale=10.0):
 

--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -902,7 +902,9 @@ def cellDef(meta_obj, surfaces, universe_box):
 
                             elif surf_type == "Cylinder":
                                 cyl = GeounedSurface(
-                                    ("Cylinder", surf_params), universe_box, Face="Build"
+                                    ("Cylinder", surf_params),
+                                    universe_box,
+                                    Face="Build",
                                 )
                                 id2, exist = surfaces.addCylinder(cyl)
 
@@ -1185,7 +1187,9 @@ def addConePlane(definition, cones_list, surfaces, universe_box):
             continue
 
         plane = GeounedSurface(
-            ("Plane", (cone.Surf.Apex, cone.Surf.Axis, 1, 1)), universe_box, Face="Build"
+            ("Plane", (cone.Surf.Apex, cone.Surf.Axis, 1, 1)),
+            universe_box,
+            Face="Build",
         )
         pid, exist = surfaces.addPlane(plane)
 

--- a/src/geouned/GEOUNED/Utils/Geometry_GU.py
+++ b/src/geouned/GEOUNED/Utils/Geometry_GU.py
@@ -12,9 +12,11 @@ from ..Utils.Options.Classes import Tolerances as tol
 from .BasicFunctions_part1 import isSameValue
 from .BasicFunctions_part2 import isSameTorus
 
+
 # SURFACES
 class SurfacesGu(object):
     """GEOUNED surface class"""
+
     def __init__(self, face):
         self.face = face
         self.Surface = self.face.Surface
@@ -28,6 +30,7 @@ class SurfacesGu(object):
 
 class PlaneGu(SurfacesGu):
     """GEOUNED Plane Class"""
+
     def __init__(self, face, plane3Pts=False):
         SurfacesGu.__init__(self, face)
         self.Axis = face.Surface.Axis
@@ -47,6 +50,7 @@ class PlaneGu(SurfacesGu):
 
 class CylinderGu(SurfacesGu):
     """GEOUNED Cylinder Class"""
+
     def __init__(self, face):
         SurfacesGu.__init__(self, face)
         self.Axis = face.Surface.Axis
@@ -57,6 +61,7 @@ class CylinderGu(SurfacesGu):
 
 class ConeGu(SurfacesGu):
     """GEOUNED Cone Class"""
+
     def __init__(self, face):
         SurfacesGu.__init__(self, face)
         self.Axis = face.Surface.Axis
@@ -69,6 +74,7 @@ class ConeGu(SurfacesGu):
 
 class SphereGu(SurfacesGu):
     """GEOUNED Sphere Class"""
+
     def __init__(self, face):
         SurfacesGu.__init__(self, face)
         self.type = self.type[0:6]
@@ -78,6 +84,7 @@ class SphereGu(SurfacesGu):
 
 class TorusGu(SurfacesGu):
     """GEOUNED Torus Class"""
+
     def __init__(self, face):
         SurfacesGu.__init__(self, face)
         self.Center = face.Surface.Center
@@ -88,6 +95,7 @@ class TorusGu(SurfacesGu):
 
 class SolidGu:
     """GEOUNED Solid Class"""
+
     def __init__(self, solid, plane3Pts=False):
         self.solid = solid
         faces = DefineListFace_GU(solid.Faces, plane3Pts)
@@ -221,6 +229,7 @@ class SolidGu:
 # FACES
 class FaceGu(object):
     """GEOUNED Face Class"""
+
     def __init__(self, face, Plane3Pts=False):
         # GEOUNED based atributes
         self.__face__ = face

--- a/src/geouned/GEOUNED/Utils/Options/Classes.py
+++ b/src/geouned/GEOUNED/Utils/Options/Classes.py
@@ -1,25 +1,27 @@
 class Options:
     from .optionsDefault import defaultValues, typeDict
+
     @classmethod
     def setDefaultAttribute(cls):
-         for key,value in cls.defaultValues.items():
-             setattr(cls, key, value)
+        for key, value in cls.defaultValues.items():
+            setattr(cls, key, value)
 
-    @classmethod 
-    def setAttribute(cls,key,value):
+    @classmethod
+    def setAttribute(cls, key, value):
         if key in cls.defaultValues.keys():
             setattr(cls, key, value)
+
 
 class Tolerances:
     from .tolerancesDefault import defaultValues, typeDict, KwrdEquiv
 
     @classmethod
     def setDefaultAttribute(cls):
-        for key,value in cls.defaultValues.items():
+        for key, value in cls.defaultValues.items():
             setattr(cls, key, value)
 
     @classmethod
-    def setAttribute(cls,key,value):
+    def setAttribute(cls, key, value):
         if key in cls.defaultValues.keys():
             setattr(cls, key, value)
 
@@ -29,10 +31,10 @@ class McnpNumericFormat:
 
     @classmethod
     def setDefaultAttribute(cls):
-         for key,value in cls.defaultValues.items():
-             setattr(cls, key, value)
-    
+        for key, value in cls.defaultValues.items():
+            setattr(cls, key, value)
+
     @classmethod
-    def setAttribute(cls,key,value):
+    def setAttribute(cls, key, value):
         if key in cls.defaultValues.keys():
             setattr(cls, key, value)

--- a/src/geouned/GEOUNED/Utils/Options/mcnpNumericDefault.py
+++ b/src/geouned/GEOUNED/Utils/Options/mcnpNumericDefault.py
@@ -1,16 +1,16 @@
 defaultValues = {
-    "P_abc": "14.7e",     # Plane general a,b,c params
-    "P_d": "14.7e",       # Plane general d     params
-    "P_xyz": "14.7e",     # PX/PY/PZ            params
-    "S_r": "14.7e",       # SO/SX/SY/SZ/S       radius
-    "S_xyz": "14.7e",     # SO/SX/SY/SZ/S       center
-    "C_r": "12f",         # Cylinder            radius
-    "C_xyz": "12f",       # Cylinder            center
-    "K_xyz": "13.6e",     # Cone                apex
-    "K_tan2": "12f",      # Cone                tan^2 value
-    "T_r": "14.7e",       # Torus               radii
-    "T_xyz": "14.7e",     # Torus               center
+    "P_abc": "14.7e",  # Plane general a,b,c params
+    "P_d": "14.7e",  # Plane general d     params
+    "P_xyz": "14.7e",  # PX/PY/PZ            params
+    "S_r": "14.7e",  # SO/SX/SY/SZ/S       radius
+    "S_xyz": "14.7e",  # SO/SX/SY/SZ/S       center
+    "C_r": "12f",  # Cylinder            radius
+    "C_xyz": "12f",  # Cylinder            center
+    "K_xyz": "13.6e",  # Cone                apex
+    "K_tan2": "12f",  # Cone                tan^2 value
+    "T_r": "14.7e",  # Torus               radii
+    "T_xyz": "14.7e",  # Torus               center
     "GQ_1to6": "18.15f",  # GQ 1 to 6 coefficients (order 2 x2,y2,z2,xy,...)
     "GQ_7to9": "18.15f",  # GQ 7 to 9 coefficients (order 1 x,y,z)
-    "GQ_10": "18.15f",    # GQ 10 coefficient      (order 0)
-}  
+    "GQ_10": "18.15f",  # GQ 10 coefficient      (order 0)
+}

--- a/src/geouned/GEOUNED/Utils/Options/optionsDefault.py
+++ b/src/geouned/GEOUNED/Utils/Options/optionsDefault.py
@@ -1,30 +1,30 @@
 # default options values
 defaultValues = {
-    "forceCylinder" : False,  # Force using cylinders instead cones for auxillary surfaces of torus surface definition
-    "newSplitPlane" : True,   # Use new module for planes splitting in decomposition module
-    "delLastNumber" : False,  # Deleting the last word in the comment if it is a number
-    "verbose" : False,        # Display information during conversion process
-    "enlargeBox" : 2,         # Enlarge box Boundary when evaluating Ctable (dimension in mm)
-    "nPlaneReverse" : 0,      # numbers of plane thresold whether cut of parallel planes are made fisrt with lowest or highest number
-    "splitTolerance" : 0,     # First try for fuzzy tolerance used in BOPTOOL Split function. If BOPTSplit crash try lower value for tolerance
-    "scaleUp" : True,         # Scale up Fuzzy tolerance once get below 1e-12
-    "quadricPY" : False,      # use quadric form of cones and cylinder not aligned with X,Y,Z axis when write openMC script file
-    "Facets" : False,         # use alternative conversion module when geometry is defined by cells compound by only triangular plane faces
-    "prnt3PPlane" : False,    # print 3 point plane definition in MCNP output as 3 points coordinates
-    "forceNoOverlap" : False, # force no overlaping cell definition. Adjacent cell definition are rested from current cell definition
+    "forceCylinder": False,  # Force using cylinders instead cones for auxillary surfaces of torus surface definition
+    "newSplitPlane": True,  # Use new module for planes splitting in decomposition module
+    "delLastNumber": False,  # Deleting the last word in the comment if it is a number
+    "verbose": False,  # Display information during conversion process
+    "enlargeBox": 2,  # Enlarge box Boundary when evaluating Ctable (dimension in mm)
+    "nPlaneReverse": 0,  # numbers of plane thresold whether cut of parallel planes are made fisrt with lowest or highest number
+    "splitTolerance": 0,  # First try for fuzzy tolerance used in BOPTOOL Split function. If BOPTSplit crash try lower value for tolerance
+    "scaleUp": True,  # Scale up Fuzzy tolerance once get below 1e-12
+    "quadricPY": False,  # use quadric form of cones and cylinder not aligned with X,Y,Z axis when write openMC script file
+    "Facets": False,  # use alternative conversion module when geometry is defined by cells compound by only triangular plane faces
+    "prnt3PPlane": False,  # print 3 point plane definition in MCNP output as 3 points coordinates
+    "forceNoOverlap": False,  # force no overlaping cell definition. Adjacent cell definition are rested from current cell definition
 }
 
 typeDict = {
-    "forceCylinder" : bool,  # Force using cylinders instead cones for auxillary surfaces of torus surface definition
-    "newSplitPlane" : bool,   # Use new module for planes splitting in decomposition module
-    "delLastNumber" : bool,  # Deleting the last word in the comment if it is a number
-    "verbose" : bool,        # Display information during conversion process
-    "enlargeBox" : float,         # Enlarge box Boundary when evaluating Ctable (dimension in mm)
-    "nPlaneReverse" : int,      # numbers of plane thresold whether cut of parallel planes are made fisrt with lowest or highest number
-    "splitTolerance" : int,     # First try for fuzzy tolerance used in BOPTOOL Split function. If BOPTSplit crash try lower value for tolerance
-    "scaleUp" : bool,         # Scale up Fuzzy tolerance once get below 1e-12
-    "quadricPY" : bool,      # use quadric form of cones and cylinder not aligned with X,Y,Z axis when write openMC script file
-    "Facets" : bool,         # use alternative conversion module when geometry is defined by cells compound by only triangular plane faces
-    "prnt3PPlane" : bool,    # print 3 point plane definition in MCNP output as 3 points coordinates
-    "forceNoOverlap" : bool, # force no overlaping cell definition. Adjacent cell definition are rested from current cell definition
+    "forceCylinder": bool,  # Force using cylinders instead cones for auxillary surfaces of torus surface definition
+    "newSplitPlane": bool,  # Use new module for planes splitting in decomposition module
+    "delLastNumber": bool,  # Deleting the last word in the comment if it is a number
+    "verbose": bool,  # Display information during conversion process
+    "enlargeBox": float,  # Enlarge box Boundary when evaluating Ctable (dimension in mm)
+    "nPlaneReverse": int,  # numbers of plane thresold whether cut of parallel planes are made fisrt with lowest or highest number
+    "splitTolerance": int,  # First try for fuzzy tolerance used in BOPTOOL Split function. If BOPTSplit crash try lower value for tolerance
+    "scaleUp": bool,  # Scale up Fuzzy tolerance once get below 1e-12
+    "quadricPY": bool,  # use quadric form of cones and cylinder not aligned with X,Y,Z axis when write openMC script file
+    "Facets": bool,  # use alternative conversion module when geometry is defined by cells compound by only triangular plane faces
+    "prnt3PPlane": bool,  # print 3 point plane definition in MCNP output as 3 points coordinates
+    "forceNoOverlap": bool,  # force no overlaping cell definition. Adjacent cell definition are rested from current cell definition
 }

--- a/src/geouned/GEOUNED/Utils/Options/tolerancesDefault.py
+++ b/src/geouned/GEOUNED/Utils/Options/tolerancesDefault.py
@@ -1,38 +1,38 @@
 defaultValues = {
     "relativeTol": False,
     "relativePrecision": 1.0e-6,  # relative precision
-    "value": 1.0e-6,              # Tolerance in single value comparison
-    "distance": 1.0e-4,           # General Distance Tolerance
-    "angle": 1.0e-4,              # General Angle Tolerance
-    "pln_distance": 1.0e-4,       # distance between planes equal planes if distance between parallel planes < 1e-4 cm
-    "pln_angle": 1.0e-4,          # angle between axis. 1e-4 : planes separate each other 0.1mm each 1m
-    "cyl_distance": 1.0e-4,       # distance between radius/center
-    "cyl_angle": 1.0e-4,          # angle between axis
-    "sph_distance": 1.0e-4,       # distance between radius/center
-    "kne_distance": 1.0e-4,       # distance between apex
-    "kne_angle": 1.0e-4,          # angle between semiangles/axis
-    "tor_distance": 1.0e-4,       # distance between Major/Minor radii/center
-    "tor_angle": 1.0e-4,          # angle between axis
-    "min_area": 1.0e-2,           # minimun face area to consider in cell definition
-}  
+    "value": 1.0e-6,  # Tolerance in single value comparison
+    "distance": 1.0e-4,  # General Distance Tolerance
+    "angle": 1.0e-4,  # General Angle Tolerance
+    "pln_distance": 1.0e-4,  # distance between planes equal planes if distance between parallel planes < 1e-4 cm
+    "pln_angle": 1.0e-4,  # angle between axis. 1e-4 : planes separate each other 0.1mm each 1m
+    "cyl_distance": 1.0e-4,  # distance between radius/center
+    "cyl_angle": 1.0e-4,  # angle between axis
+    "sph_distance": 1.0e-4,  # distance between radius/center
+    "kne_distance": 1.0e-4,  # distance between apex
+    "kne_angle": 1.0e-4,  # angle between semiangles/axis
+    "tor_distance": 1.0e-4,  # distance between Major/Minor radii/center
+    "tor_angle": 1.0e-4,  # angle between axis
+    "min_area": 1.0e-2,  # minimun face area to consider in cell definition
+}
 
 typeDict = {
     "relativeTol": bool,
     "relativePrecision": float,  # relative precision
-    "value": float,              # Tolerance in single value comparison
-    "distance": float,           # General Distance Tolerance
-    "angle": float,              # General Angle Tolerance
-    "pln_distance": float,       # distance between planes equal planes if distance between parallel planes < 1e-4 cm
-    "pln_angle": float,          # angle between axis. 1e-4 : planes separate each other 0.1mm each 1m
-    "cyl_distance": float,       # distance between radius/center
-    "cyl_angle": float,          # angle between axis
-    "sph_distance": float,       # distance between radius/center
-    "kne_distance": float,       # distance between apex
-    "kne_angle": float,          # angle between semiangles/axis
-    "tor_distance": float,       # distance between Major/Minor radii/center
-    "tor_angle": float,          # angle between axis
-    "min_area": float,           # minimun face area to consider in cell definition
-}  
+    "value": float,  # Tolerance in single value comparison
+    "distance": float,  # General Distance Tolerance
+    "angle": float,  # General Angle Tolerance
+    "pln_distance": float,  # distance between planes equal planes if distance between parallel planes < 1e-4 cm
+    "pln_angle": float,  # angle between axis. 1e-4 : planes separate each other 0.1mm each 1m
+    "cyl_distance": float,  # distance between radius/center
+    "cyl_angle": float,  # angle between axis
+    "sph_distance": float,  # distance between radius/center
+    "kne_distance": float,  # distance between apex
+    "kne_angle": float,  # angle between semiangles/axis
+    "tor_distance": float,  # distance between Major/Minor radii/center
+    "tor_angle": float,  # angle between axis
+    "min_area": float,  # minimun face area to consider in cell definition
+}
 
 KwrdEquiv = {
     "relativeTolerance": "relativeTol",

--- a/src/geouned/GEOUNED/Utils/booleanFunction.py
+++ b/src/geouned/GEOUNED/Utils/booleanFunction.py
@@ -4,17 +4,28 @@
 
 import re
 
-mostinner = re.compile(r"\([^\(^\)]*\)")           # identify most inner parentheses
-number = re.compile(r"(?P<value>[-+]?\d+)")        # identify signed integer and record its value in <value>
-mix = re.compile(r"(?P<value>([-+]?\d+|\[0+\]))")  # identify signed integer or [000...] pattern. Record the value. 
-TFX = re.compile(r"(?P<value>[FTXo]+)")            # identify pattern incluinding F,T,X, or o sequence ( in any order).
-PValue = re.compile(r"P\d+")                       # identify pattern "P" + integer pattern (e.g. P3915).
-NValue = re.compile(r"N\d+")                       # identify pattern "N" + integer pattern (e.g. N3358).
-conversion = {"T": True, "F": False, "X": None}    # associate "T", "F", "X" with associated Boolean value (or None for X)
+mostinner = re.compile(r"\([^\(^\)]*\)")  # identify most inner parentheses
+number = re.compile(
+    r"(?P<value>[-+]?\d+)"
+)  # identify signed integer and record its value in <value>
+mix = re.compile(
+    r"(?P<value>([-+]?\d+|\[0+\]))"
+)  # identify signed integer or [000...] pattern. Record the value.
+TFX = re.compile(
+    r"(?P<value>[FTXo]+)"
+)  # identify pattern incluinding F,T,X, or o sequence ( in any order).
+PValue = re.compile(r"P\d+")  # identify pattern "P" + integer pattern (e.g. P3915).
+NValue = re.compile(r"N\d+")  # identify pattern "N" + integer pattern (e.g. N3358).
+conversion = {
+    "T": True,
+    "F": False,
+    "X": None,
+}  # associate "T", "F", "X" with associated Boolean value (or None for X)
 
 
 class BoolSequence:
     """Class storing Boolean expression and operating on it"""
+
     def __init__(self, definition=None, operator=None):
         if definition:
             self.elements = []
@@ -39,10 +50,10 @@ class BoolSequence:
 
     def append(self, *seq):
         """Append a BoolSequence Objects. seq may be :
-          - An iterable containing allowed BoolSequence Objects
-          - A BoolSequence object
-          - An integer value
-          - A Boolean value"""
+        - An iterable containing allowed BoolSequence Objects
+        - A BoolSequence object
+        - An integer value
+        - A Boolean value"""
         for s in seq:
             if type(s) is int:
                 level = -1
@@ -81,7 +92,7 @@ class BoolSequence:
             self.level = max(self.level, level + 1)
 
     def assign(self, Seq):
-        """Assign the BoolSequence Seq to the self instance BoolSequence""" 
+        """Assign the BoolSequence Seq to the self instance BoolSequence"""
         if type(Seq) is bool:
             self.operator == "AND"
             self.elements = Seq
@@ -302,8 +313,9 @@ class BoolSequence:
                 return False
 
     def substitute(self, var, val):
-        """Substitute in the BoolSequence the variable "var" by the value "val". 
-        "val" can be an Boolean value or an integer representing another surface variable."""
+        """Substitute in the BoolSequence the variable "var" by the value "val".
+        "val" can be an Boolean value or an integer representing another surface variable.
+        """
         if val is None:
             return
         if type(self.elements) is bool:
@@ -565,7 +577,8 @@ class BoolSequence:
 
     def setDef(self, expression):
         """Set the expression of the Boolean function in the BoolSequence instance.
-        "expresion" is the string object. The definition should have MCNP syntax cell definition. """
+        "expresion" is the string object. The definition should have MCNP syntax cell definition.
+        """
         terms, operator = outterTerms(expression)
         self.operator = operator
         self.level = 0
@@ -595,8 +608,8 @@ class BoolSequence:
         self.groupSingle()
 
     def groupSingle(self):
-        """ group integers found in Sequence with level > 1.
-        (e.g. change AND[1 2 3 OR[2 4]] to AND[ AND[1 2 3] OR[2 3]] ). """
+        """group integers found in Sequence with level > 1.
+        (e.g. change AND[1 2 3 OR[2 4]] to AND[ AND[1 2 3] OR[2 3]] )."""
         if self.level == 0:
             return
         if type(self.elements) is bool:

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -153,14 +153,14 @@ class CadToCsg:
         self.sortEnclosure = sortEnclosure
 
         Options.setDefaultAttribute()
-        McnpNumericFormat.setDefaultAttribute()  
-        Tolerances.setDefaultAttribute() 
+        McnpNumericFormat.setDefaultAttribute()
+        Tolerances.setDefaultAttribute()
 
-    def SetConfiguration(self,configFile=None):
+    def SetConfiguration(self, configFile=None):
 
-        if configFile is None :
+        if configFile is None:
             return
-      
+
         config = configparser.ConfigParser()
         config.optionxform = str
         config.read(configFile)
@@ -235,25 +235,34 @@ class CadToCsg:
             elif section == "Options":
                 for key in config["Options"].keys():
                     if key in Options.defaultValues.keys():
-                        if Options.typeDict[key] is bool :  
-                            Options.setAttribute(key,config.getboolean("Options", key))
-                        elif Options.typeDict[key] is float or Options.typeDict[key] is int:
-                            Options.setAttribute(key,config.getfloat("Options", key))
+                        if Options.typeDict[key] is bool:
+                            Options.setAttribute(key, config.getboolean("Options", key))
+                        elif (
+                            Options.typeDict[key] is float
+                            or Options.typeDict[key] is int
+                        ):
+                            Options.setAttribute(key, config.getfloat("Options", key))
 
             elif section == "Tolerances":
                 for key in config["Tolerances"].keys():
                     eqvKey = Tolerances.KwrdEquiv[key]
                     if eqvKey in Tolerances.defaultValues.keys():
-                         if Tolerances.typeDict[eqvKey] is bool :
-                            Tolerances.setAttribute(eqvKey,config.getboolean("Tolerances", key))
-                         elif Tolerances.typeDict[eqvKey] is float:
-                            Tolerances.setAttribute(eqvKey,config.getfloat("Tolerances", key))
+                        if Tolerances.typeDict[eqvKey] is bool:
+                            Tolerances.setAttribute(
+                                eqvKey, config.getboolean("Tolerances", key)
+                            )
+                        elif Tolerances.typeDict[eqvKey] is float:
+                            Tolerances.setAttribute(
+                                eqvKey, config.getfloat("Tolerances", key)
+                            )
 
             elif section == "MCNP_Numeric_Format":
                 PdEntry = False
                 for key in config["MCNP_Numeric_Format"].keys():
                     if key in McnpNumericFormat.defaultValues.keys():
-                        McnpNumericFormat.setAttribute(key,config.get("MCNP_Numeric_Format", key))
+                        McnpNumericFormat.setAttribute(
+                            key, config.get("MCNP_Numeric_Format", key)
+                        )
                         if key == "P_d":
                             PdEntry = True
 
@@ -271,13 +280,13 @@ class CadToCsg:
     def set(self, kwrd, value):
 
         if kwrd in McnpNumericFormat.defaultValues.keys():
-            McnpNumericFormat.setAttribute(kwrd,value)
+            McnpNumericFormat.setAttribute(kwrd, value)
             return
         elif kwrd in Tolerances.defaultValues.keys():
-            Tolerances.setAttribute(kwrd,value)
+            Tolerances.setAttribute(kwrd, value)
             return
         elif kwrd in Options.defaultValues.keys():
-            Options.setAttribute(kwrd,value)
+            Options.setAttribute(kwrd, value)
             return
         elif kwrd not in self.__dict__.keys():
             print("Bad entry : {}".format(kwrd))
@@ -388,9 +397,7 @@ class CadToCsg:
 
         # Select a specific solid range from original STEP solids
         if self.cellRange:
-            MetaList = MetaList[
-                self.cellRange[0] : self.cellRange[1]
-            ]
+            MetaList = MetaList[self.cellRange[0] : self.cellRange[1]]
 
         # export in STEP format solids read from input file
         # terminate excution
@@ -402,7 +409,7 @@ class CadToCsg:
                 solids.extend(m.Solids)
             Part.makeCompound(solids).exportStep(self.exportSolids)
             msg = (
-                f'Solids exported in file {self.exportSolids}\n'
+                f"Solids exported in file {self.exportSolids}\n"
                 "GEOUNED Finish. No solid translation performed."
             )
             raise ValueError(msg)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -19,35 +19,35 @@ def test_conversion(input_step_file):
 
     # creates the config file contents
     template = {
-        "title" : 'Input Test' ,
-        "stepFile" : f"{input_step_file.resolve()}" ,
-        "geometryName" : f"{output_filename_stem.resolve()}" ,
-        "outFormat" : ('mcnp', 'openMC_XML') ,
-        "compSolids" : False ,
-        "volCARD" : False ,
-        "volSDEF" : True ,
-        "voidGen" : True ,
-        "dummyMat" : True ,
-        "minVoidSize" : 100 ,
-        "cellSummaryFile" : False ,
-        "cellCommentFile" : False ,
-        "debug" : False ,
-        "simplify" : 'no' ,
-        "forceCylinder" :  False ,
-        "splitTolerance" : 0 ,
-        "newSplitPlane" : True ,
-        "nPlaneReverse" : 0 ,
+        "title": "Input Test",
+        "stepFile": f"{input_step_file.resolve()}",
+        "geometryName": f"{output_filename_stem.resolve()}",
+        "outFormat": ("mcnp", "openMC_XML"),
+        "compSolids": False,
+        "volCARD": False,
+        "volSDEF": True,
+        "voidGen": True,
+        "dummyMat": True,
+        "minVoidSize": 100,
+        "cellSummaryFile": False,
+        "cellCommentFile": False,
+        "debug": False,
+        "simplify": "no",
+        "forceCylinder": False,
+        "splitTolerance": 0,
+        "newSplitPlane": True,
+        "nPlaneReverse": 0,
     }
 
     # deletes the output openmc and mcnp output files if it already exists
     output_filename_stem.with_suffix(".mcnp").unlink(missing_ok=True)
     output_filename_stem.with_suffix(".xml").unlink(missing_ok=True)
 
-    GEO = CadToCsg('Input Test')
+    GEO = CadToCsg("Input Test")
 
     # set parameters values stored in template dictionary
-    for key,value in template.items():
-      GEO.set(key, value)
+    for key, value in template.items():
+        GEO.set(key, value)
 
     GEO.Start()
 


### PR DESCRIPTION
This PR adds a new action to the CI

The action runs black with default settings (easy for the user to reproduce)

If the code is not formatted as black would format it then the CI will fail and provide formatting comments in the CI logs

If the code would be unchanged by black then the CI passes.

This first commit should fail the new CI check (called lintr) as there has been some non PEP8 code added since I formatted the whole repo on pr #72 

I will then run ```black``` locally and the push again and the CI should pass

This is quite strict so feel free to reject this PR but I think it is one way of keeping the code formatted with PEP8 even though black style is not universally liked it can save develop time fixing spaces and indentation and simple stuff like that