### PR TITLE
f strings instead of .format

### DIFF
--- a/src/geouned/GEOReverse/Modules/MCNPinput.py
+++ b/src/geouned/GEOReverse/Modules/MCNPinput.py
@@ -1118,7 +1118,7 @@ def get_hyperboloid_parameters(eVal, eVect, T, k, iaxis):
     else:
         if ellipsoid:
             print("ellipical hyperboloid not implemented")
-            print("single radius from {} eigen Value will be used".format(minorRad))
+            print(f"single radius from {minorRad} eigen Value will be used")
         return "hyperboloid", (
             pos,
             axis,

--- a/src/geouned/GEOReverse/Modules/Objects.py
+++ b/src/geouned/GEOReverse/Modules/Objects.py
@@ -206,7 +206,7 @@ class Plane:
             self.transform(tr)
 
     def __str__(self):
-        return "plane : {}\nParameters : {}".format(self.id, self.params)
+        return f"plane : {self.id}\nParameters : {self.params}"
 
     def copy(self):
         return Plane(self.id, self.params)

--- a/src/geouned/GEOReverse/Modules/Parser/parser.py
+++ b/src/geouned/GEOReverse/Modules/Parser/parser.py
@@ -43,7 +43,7 @@ re_fll = re.compile(
 
 # If type specifier not given, any data type can be formatted:
 def fmt_gen(s):
-    return "{" + ":<{}".format(len(s)) + "}"
+    return "{" + f":<{len(s)}" + "}"
 
 
 fmt_d = fmt_gen
@@ -204,9 +204,7 @@ class Card(object):
         d = self.debug
         if d:
             print(
-                "Line {}, {} card. {}".format(
-                    self.pos, CID.get_name(self.ctype), comment
-                ),
+                f"Line {self.pos}, {CID.get_name(self.ctype)} card. {comment}",
                 file=d,
             )
             if "t" in key:
@@ -670,7 +668,7 @@ class Card(object):
                                 # there is no proper place to wrap.
                                 self.print_debug("Cannot wrap line " + repr(i), "")
                                 warnings.warn(
-                                    "Cannot wrap card" " on line {}".format(self.pos)
+                                    f"Cannot wrap card on line {self.pos}"
                                 )
                                 break
                         else:
@@ -1226,7 +1224,7 @@ if version == "2.7":
         from os import stat
 
         iname = inp
-        dname = ".{}.~".format(os.path.basename(inp))
+        dname = f".{os.path.basename(inp)}.~"
         try:
             it = stat(iname).st_mtime
         except OSError as e:
@@ -1272,7 +1270,7 @@ def index_(line, chars="$&"):
     """
     Find the first index of one of the chars in line.
     """
-    r = re.compile("[{}]".format(chars))
+    r = re.compile(f"[{chars}]")
     m = r.search(line)
     if m:
         i = m.end() - 1
@@ -1303,7 +1301,7 @@ def get_cards_from_input(inp, debug=None, preservetabs=False):
             while "\t" in l:
                 i = l.index("\t")
                 ii = (i // ts + 1) * ts - i
-                print("c Line {}: tab replaced with {} spaces".format(cln + 1, ii))
+                print(f"c Line {cln + 1}: tab replaced with {ii} spaces")
                 l = l[:i] + " " * ii + l[i + 1 :]
             return l[:]
 
@@ -1505,7 +1503,7 @@ def are_close_lists(x, y, re=1e-6, pci=[]):
             for xx, yy in zip(xl, yl):
                 r = are_close_vals(xx, yy, re)
                 if not r:
-                    m = "diff at {}".format(n)
+                    m = f"diff at {n}"
                     break
             else:
                 m = "all elements are close or equal"

--- a/src/geouned/GEOReverse/Modules/Utils/BooleanSolids.py
+++ b/src/geouned/GEOReverse/Modules/Utils/BooleanSolids.py
@@ -95,25 +95,25 @@ class ConstraintTable(dict):
             line = ""
             for name in varName:
                 element = self[name][name]
-                line += " {:4d} : {}\n".format(name, element.val)
+                line += f" {name:4d} : {element.val}\n"
             return line
 
         outstr = "  "
         for name in varName:
-            outstr = outstr + " {:3d}".format(name)
+            outstr = outstr + f" {name:3d}"
         outstr = outstr + "\n"
 
         for name1 in varName:
-            line = " {:3d} ".format(name1)
-            linenot = "~{:3d} ".format(name1)
+            line = f" {name1:3d} "
+            linenot = f"~{name1:3d} "
             for name2 in varName:
                 elmt = self[name1][name2]
                 if elmt.diagonal:
-                    line += " {:>2d} ".format(elmt.val)
+                    line += f" {elmt.val:>2d} "
                     linenot += "    "
                 else:
-                    line += " {}{} ".format(elmt.val[0], elmt.val[1])
-                    linenot += " {}{} ".format(elmt.val[3], elmt.val[2])
+                    line += f" {elmt.val[0]}{elmt.val[1]} "
+                    linenot += f" {elmt.val[3]}{elmt.val[2]} "
             outstr += line + "\n"
             outstr += linenot + "\n"
         return outstr
@@ -457,7 +457,7 @@ def point_inside(solid):
         n = n + 1
 
         if n == cut_box:
-            print("Solid not found in bounding Box (Volume : {})".format(solid.Volume))
+            print(f"Solid not found in bounding Box (Volume : {solid.Volume})")
             return None
 
 

--- a/src/geouned/GEOReverse/Modules/Utils/booleanFunction.py
+++ b/src/geouned/GEOReverse/Modules/Utils/booleanFunction.py
@@ -20,12 +20,12 @@ class BoolSequence:
             self.level = 0
 
     def __str__(self):
-        out = "{}[".format(self.operator)
+        out = f"{self.operator}["
         if type(self.elements) is bool:
             return " True " if self.elements else " False "
         for e in self.elements:
             if type(e) is int or type(e) is bool or type(e) is str:
-                out += " {} ".format(e)
+                out += f" {e} "
             else:
                 out += e.__str__()
 

--- a/src/geouned/GEOReverse/Modules/buildCAD.py
+++ b/src/geouned/GEOReverse/Modules/buildCAD.py
@@ -107,9 +107,7 @@ def BuildUniverse(
     Universe = AllUniverses[Ustart]
 
     print(
-        "Build Universe {} in container cell {}".format(
-            ContainerCell.FILL, ContainerCell.name
-        )
+        f"Build Universe {ContainerCell.FILL} in container cell {ContainerCell.name}"
     )
     fails = []
     for NTcell in Universe.values():
@@ -136,7 +134,7 @@ def BuildUniverse(
             NTcell = NTcell.copy()
 
         if buildShape:
-            print("Level :{}  build Cell {} ".format(CC.level + 1, NTcell.name))
+            print(f"Level :{CC.level + 1}  build Cell {NTcell.name} ")
             if type(NTcell.definition) is not BoolSequence:
                 NTcell.definition = BoolSequence(NTcell.definition.str)
 
@@ -187,15 +185,15 @@ def makeTree(CADdoc, CADCells):
     label, universeCADCells = CADCells
     groupObj = CADdoc.addObject("App::Part", "Materials")
 
-    groupObj.Label = "Universe_{}_Container_{}".format(label[1], label[0])
+    groupObj.Label = f"Universe_{label[1]}_Container_{label[0]}"
 
     CADObj = {}
     for i, c in enumerate(universeCADCells):
         if type(c) is tuple:
             groupObj.addObject(makeTree(CADdoc, c))
         else:
-            featObj = CADdoc.addObject("Part::FeaturePython", "solid{}".format(i))
-            featObj.Label = "Cell_{}_{}".format(c.name, c.MAT)
+            featObj = CADdoc.addObject("Part::FeaturePython", f"solid{i}")
+            featObj.Label = f"Cell_{c.name}_{c.MAT}"
             featObj.Shape = c.shape
             if c.MAT not in CADObj.keys():
                 CADObj[c.MAT] = [featObj]
@@ -204,7 +202,7 @@ def makeTree(CADdoc, CADCells):
 
     for mat, matGroup in CADObj.items():
         groupMatObj = CADdoc.addObject("App::Part", "Materials")
-        groupMatObj.Label = "Material_{}".format(mat)
+        groupMatObj.Label = f"Material_{mat}"
         groupMatObj.addObjects(matGroup)
         groupObj.addObject(groupMatObj)
 

--- a/src/geouned/GEOReverse/Modules/processInp.py
+++ b/src/geouned/GEOReverse/Modules/processInp.py
@@ -88,7 +88,7 @@ def getSetting(config):
         elif key == "inFormat":
             inFormat = config.get("Setting", key)
         else:
-            print("{} bad keyword. Ignored".format(key))
+            print(f"{key} bad keyword. Ignored")
 
     return fileIn, fileOut, outBox, inFormat
 
@@ -108,7 +108,7 @@ def getLevel(config):
         elif key == "UStart":
             UStart = config.getint("Levels", key)
         else:
-            print("{} bad keyword. Ignored".format(key))
+            print(f"{key} bad keyword. Ignored")
 
     return UStart, levMax
 
@@ -122,7 +122,7 @@ def getRange(section, config):
         elif key == "range":
             rawRange = config.get(section, key)
         else:
-            print("{} bad keyword. Ignored".format(key))
+            print(f"{key} bad keyword. Ignored")
 
     if rType is None:
         return None
@@ -132,7 +132,7 @@ def getRange(section, config):
     elif rType.lower() == "exclude" or rType.lower() == "include":
         ctRange = getRangeData(rawRange)
         if ctRange is None:
-            print("bad range in section {}".format(section))
+            print(f"bad range in section {section}")
             return None
         else:
             return (rType.lower(), ctRange)
@@ -198,7 +198,7 @@ def setSecOptions(config):
             tolerance = config.getfloat("Options", key)
             setattr(Options, key, tolerance)
         else:
-            print("{} bad keyword. Ignored".format(key))
+            print(f"{key} bad keyword. Ignored")
 
     return
 

--- a/src/geouned/GEOReverse/Modules/remh.py
+++ b/src/geouned/GEOReverse/Modules/remh.py
@@ -452,7 +452,7 @@ class Cline:
             self.str = self.str[0 : m.start()] + s2 + self.str[m.end() :]
             return m.start() + len(s2)
         else:
-            print("number {} not found".format(surf))
+            print(f"number {surf} not found")
             return -1
 
     def countP(self):

--- a/src/geouned/GEOReverse/Modules/splitFunction.py
+++ b/src/geouned/GEOReverse/Modules/splitFunction.py
@@ -183,7 +183,7 @@ def point_inside(solid):
         n = n + 1
 
         if n == cut_box:
-            print("Solid not found in bounding Box (Volume : {})".format(solid.Volume))
+            print(f"Solid not found in bounding Box (Volume : {solid.Volume})")
             print("Valid Solid : ", solid.isValid())
             return None
 
@@ -371,7 +371,7 @@ def surface_side(p, surf):
                 break
 
     else:
-        print("surface type {} not considered".format(surf[0]))
+        print(f"surface type {surf[0]} not considered")
         return
 
     return inout > 0

--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -386,7 +386,7 @@ def GenPlaneCylinder_old(face, solid):
 
     U_val_str_cl = []
     for i, elem1 in enumerate(U_val):
-        num_str1 = "%11.4E" % elem1
+        num_str1 = f"{elem1:11.4E}"
         if abs(elem1) < 1.0e-5:
             num_str1 = "%11.4E" % 0.0
         if not (BF.isDuplicateInList(num_str1, i, U_val)):
@@ -522,7 +522,7 @@ def GenPlaneCone_old(face, solid):
     u_val_str_cl = []
 
     for i, elem1 in enumerate(u_val):
-        num_str1 = "%11.4E" % elem1
+        num_str1 = f"{elem1:11.4E}"
         if abs(elem1) < 1.0e-5:
             num_str1 = "%11.4E" % 0.0
         if not (BF.isDuplicateInList(num_str1, i, u_val)):
@@ -991,7 +991,7 @@ def cellDef(meta_obj, surfaces, universe_box):
                     if extra[0] not in surf_piece:
                         surf_piece.append(extra[0])
                 else:
-                    surf_piece.append(f"({":".join(extra)})")
+                    surf_piece.append(f"({':'.join(extra)})")
 
         surf_piece_bool = BoolSequence(" ".join(surf_piece))
         # possible expresion for e

--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -991,7 +991,7 @@ def cellDef(meta_obj, surfaces, universe_box):
                     if extra[0] not in surf_piece:
                         surf_piece.append(extra[0])
                 else:
-                    surf_piece.append("({})".format(":".join(extra)))
+                    surf_piece.append(f"({":".join(extra)})")
 
         surf_piece_bool = BoolSequence(" ".join(surf_piece))
         # possible expresion for e

--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -89,13 +89,13 @@ def translate(meta_list, surfaces, universe_box, setting):
     for i, m in enumerate(meta_list):
         if m.IsEnclosure:
             continue
-        print("Decomposing solid: {}/{} ".format(i, tot_solid))
+        print(f"Decomposing solid: {i}/{tot_solid} ")
         if setting["debug"]:
             print(m.Comments)
             if m.IsEnclosure:
-                m.Solids[0].exportStep("origEnclosure_{}.stp".format(i))
+                m.Solids[0].exportStep(f"origEnclosure_{i}.stp")
             else:
-                m.Solids[0].exportStep("origSolid_{}.stp".format(i))
+                m.Solids[0].exportStep(f"origSolid_{i}.stp")
 
         surfaces.extend(
             Decom.ExtractSurfaces(

--- a/src/geouned/GEOUNED/Decompose/Decom_one.py
+++ b/src/geouned/GEOUNED/Decompose/Decom_one.py
@@ -473,7 +473,7 @@ def GenPlaneCylinder(face, solid):
     Uval_str_cl = []
 
     for i, elem1 in enumerate(Uval):
-        num_str1 = "%11.4E" % elem1
+        num_str1 = f"{elem1:11.4E}"
         if abs(elem1) < 1.0e-5:
             num_str1 = "%11.4E" % 0.0
 
@@ -597,7 +597,7 @@ def GenPlaneCone(face, solid):
     Uval_str_cl = []
 
     for i, elem1 in enumerate(Uval):
-        num_str1 = "%11.4E" % elem1
+        num_str1 = f"{elem1:11.4E}"
         if abs(elem1) < 1.0e-5:
             num_str1 = "%11.4E" % 0.0
         if not (isDuplicateInList(num_str1, i, Uval)):
@@ -1048,7 +1048,7 @@ def splitComponent(solidShape, universe_box):
 
     if abs(Volch) > 1e-2:  # 1% of Volume change
         if opt.verbose:
-            print("Warning: Volume has changed after decomposition: %11.4E" % Volch)
+            print(f"Warning: Volume has changed after decomposition: {Volch:11.4E}")
         err += 4
 
     return comsolid, err

--- a/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
@@ -241,7 +241,7 @@ def checkEnclosure(freecad_doc, enclosure_list):
         print("Following enclosure produce loop")
         for p in encl_dict.keys():
             for s in encl_dict[p]:
-                print("{}_{}".format(s, p))
+                print(f"{s}_{p}")
         raise ValueError("GEOUNED.LoadFunctions.checkEnclosure failed")
 
     # check enclosures solids are correctly nested and don't overlap each other

--- a/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
@@ -41,7 +41,7 @@ def LoadCAD(filename, mat_filename, default_mat=[], comp_solids=True):
         if os.path.exists(mat_filename):
             m_dict = extractMaterials(mat_filename)
         else:
-            print("Material definition file {} does not exist.".format(mat_filename))
+            print(f"Material definition file {mat_filename} does not exist.")
             m_dict = {}
     else:
         m_dict = {}
@@ -135,7 +135,7 @@ def LoadCAD(filename, mat_filename, default_mat=[], comp_solids=True):
                     n_solids = len(elem.Shape.Solids)
 
                 for i in range(n_solids):
-                    meta_list[i_solid].setComments("{}{}".format(comment, (i + 1)))
+                    meta_list[i_solid].setComments(f"{comment}{i + 1}")
                     meta_list[i_solid].setCADSolid()
 
                     if tempre_mat:

--- a/src/geouned/GEOUNED/Utils/BasicFunctions_part1.py
+++ b/src/geouned/GEOUNED/Utils/BasicFunctions_part1.py
@@ -118,11 +118,9 @@ class Plane3PtsParams:
         #    Point 2  : {P2[0]}  {P2[1]}  {P2[2]}
         #    Point 3  : {P3[0]}  {P3[1]}  {P3[2]} '''.format(P1=self.Points[0], P2=self.Points[1], P3=self.Points[2])
         pos = self.Axis.dot(self.Position)
-        outstr = """Plane :
-    Axis     : {}  {}  {} 
-    Position : {}  """.format(
-            self.Axis.x, self.Axis.y, self.Axis.z, pos
-        )
+        outstr = f"""Plane :
+    Axis     : {self.Axis.x}  {self.Axis.y}  {self.Axis.z} 
+    Position : {pos}  """
         return outstr
 
 
@@ -137,11 +135,9 @@ class PlaneParams:
 
     def __str__(self):
         pos = self.Axis.dot(self.Position)
-        outstr = """Plane :
-    Axis     : {}  {}  {} 
-    Position : {}  """.format(
-            self.Axis.x, self.Axis.y, self.Axis.z, pos
-        )
+        outstr = f"""Plane :
+    Axis     : {self.Axis.x}  {self.Axis.y}  {self.Axis.z} 
+    Position : {pos}  """
         return outstr
 
 
@@ -154,18 +150,10 @@ class CylinderParams:
         self.real = real
 
     def __str__(self):
-        outstr = """Cylinder :
-    Axis     : {}  {}  {} 
-    Center   : {}  {}  {}
-    Radius   : {}  """.format(
-            self.Axis.x,
-            self.Axis.y,
-            self.Axis.z,
-            self.Center.x,
-            self.Center.y,
-            self.Center.z,
-            self.Radius,
-        )
+        outstr = f"""Cylinder :
+    Axis     : {self.Axis.x}  {self.Axis.y}  {self.Axis.z} 
+    Center   : {self.Center.x}  {self.Center.y}  {self.Center.z}
+    Radius   : {self.Radius}  """
         return outstr
 
 
@@ -179,18 +167,10 @@ class ConeParams:
         self.real = real
 
     def __str__(self):
-        outstr = """Cone :
-    Axis     : {}  {}  {} 
-    Center   : {}  {}  {}
-    SemiAngle: {}  """.format(
-            self.Axis.x,
-            self.Axis.y,
-            self.Axis.z,
-            self.Apex.x,
-            self.Apex.y,
-            self.Apex.z,
-            self.SemiAngle,
-        )
+        outstr = f"""Cone :
+    Axis     : {self.Axis.x}  {self.Axis.y}  {self.Axis.z} 
+    Center   : {self.Apex.x}  {self.Apex.y}  {self.Apex.z}
+    SemiAngle: {self.SemiAngle}  """
         return outstr
 
 
@@ -200,11 +180,9 @@ class SphereParams:
         self.Radius = params[1]
 
     def __str__(self):
-        outstr = """Sphere :
-    Center   : {}  {}  {}
-    Radius   : {}  """.format(
-            self.Center.x, self.Center.y, self.Center.z, self.Radius
-        )
+        outstr = f"""Sphere :
+    Center   : {self.Center.x}  {self.Center.y}  {self.Center.z}
+    Radius   : {self.Radius}  """
         return outstr
 
 
@@ -216,18 +194,9 @@ class TorusParams:
         self.MinorRadius = params[3]
 
     def __str__(self):
-        outstr = """Torus :
-    Axis     : {}  {}  {} 
-    Center   : {}  {}  {}
-    MajorRadius: {}
-    MinorRadius: {} """.format(
-            self.Axis.x,
-            self.Axis.y,
-            self.Axis.z,
-            self.Center.x,
-            self.Center.y,
-            self.Center.z,
-            self.MajorRadius,
-            self.MinorRadius,
-        )
+        outstr = f"""Torus :
+    Axis     : {self.Axis.x}  {self.Axis.y}  {self.Axis.z} 
+    Center   : {self.Center.x}  {self.Center.y}  {self.Center.z}
+    MajorRadius: {self.MajorRadius}
+    MinorRadius: {self.MinorRadius} """
         return outstr

--- a/src/geouned/GEOUNED/Utils/BasicFunctions_part2.py
+++ b/src/geouned/GEOUNED/Utils/BasicFunctions_part2.py
@@ -148,9 +148,9 @@ def isDuplicateInList(num_str1, i, lista):
     for j, elem2 in enumerate(lista):
         if i == j:
             continue
-        num_str2 = "%11.4E" % (elem2)
-        num_str3 = "%11.4E" % (elem2 + 2.0 * math.pi)
-        num_str4 = "%11.4E" % (elem2 - 2.0 * math.pi)
+        num_str2 = f"{elem2:11.4E}"
+        num_str3 = f"{elem2 + 2.0 * math.pi:11.4E}"
+        num_str4 = f"{elem2 - 2.0 * math.pi:11.4E}"
 
         if abs(float(num_str2)) < 1.0e-5:
             num_str2 = "%11.4E" % 0.0

--- a/src/geouned/GEOUNED/Utils/BooleanSolids.py
+++ b/src/geouned/GEOUNED/Utils/BooleanSolids.py
@@ -96,25 +96,25 @@ class ConstraintTable(dict):
             line = ""
             for name in varName:
                 element = self[name][name]
-                line += " {:4d} : {}\n".format(name, element.val)
+                line += f" {name:4d} : {element.val}\n"
             return line
 
         outstr = "  "
         for name in varName:
-            outstr = outstr + " {:3d}".format(name)
+            outstr = outstr + f" {name:3d}"
         outstr = outstr + "\n"
 
         for name1 in varName:
-            line = " {:3d} ".format(name1)
-            linenot = "~{:3d} ".format(name1)
+            line = f" {name1:3d} "
+            linenot = f"~{name1:3d} "
             for name2 in varName:
                 elmt = self[name1][name2]
                 if elmt.diagonal:
-                    line += " {:>2d} ".format(elmt.val)
+                    line += f" {elmt.val:>2d} "
                     linenot += "    "
                 else:
-                    line += " {}{} ".format(elmt.val[0], elmt.val[1])
-                    linenot += " {}{} ".format(elmt.val[3], elmt.val[2])
+                    line += f" {elmt.val[0]}{elmt.val[1]} "
+                    linenot += f" {elmt.val[3]}{elmt.val[2]} "
             outstr += line + "\n"
             outstr += linenot + "\n"
         return outstr
@@ -510,7 +510,7 @@ def pointFromSurface(solid):
             d *= 0.5
             pp = pface + d * normal
 
-    print("Solid not found in bounding Box (Volume : {})".format(solid.Volume))
+    print(f"Solid not found in bounding Box (Volume : {solid.Volume})")
     return None
 
 

--- a/src/geouned/GEOUNED/Utils/Functions.py
+++ b/src/geouned/GEOUNED/Utils/Functions.py
@@ -369,7 +369,7 @@ class GeounedSurface:
             self.shape = torus.Faces[0]
             return
         else:
-            print("Error: Type {} is not defined".format(self.Type))
+            print(f"Error: Type {self.Type} is not defined")
             return
 
 
@@ -416,7 +416,7 @@ class SurfacesDict(dict):
             self.__last_obj__ = (key, i)
             return self[key][i]
 
-        print("Index {} not found in Surfaces".format(index))
+        print(f"Index {index} not found in Surfaces")
         return None
 
     def delSurface(self, index):

--- a/src/geouned/GEOUNED/Utils/booleanFunction.py
+++ b/src/geouned/GEOUNED/Utils/booleanFunction.py
@@ -25,12 +25,12 @@ class BoolSequence:
             self.level = 0
 
     def __str__(self):
-        out = "{}[".format(self.operator)
+        out = f"{self.operator}["
         if type(self.elements) is bool:
             return " True " if self.elements else " False "
         for e in self.elements:
             if type(e) is int or type(e) is bool or type(e) is str:
-                out += " {} ".format(e)
+                out += f" {e} "
             else:
                 out += e.__str__()
 

--- a/src/geouned/GEOUNED/Void/Void.py
+++ b/src/geouned/GEOUNED/Void/Void.py
@@ -53,7 +53,7 @@ def voidGeneration(MetaList, EnclosureList, Surfaces, UniverseBox, setting, init
             if encl.CellType == "envelope":
                 continue
             newMetaList = VF.selectSolids(MetaList, encl.SonEnclosures, encl)
-            print("Build Void enclosure {} in enclosure level {}".format(j, i + 1))
+            print(f"Build Void enclosure {j} in enclosure level {i + 1}")
             # select solids overlapping current enclosure "encl", and lower level enclosures
             voids = GetVoidDef(newMetaList, Surfaces, encl, setting)
             voidList.append(voids)
@@ -94,7 +94,7 @@ def GetVoidDef(MetaList, Surfaces, Enclosure, setting, Lev0=False):
             nsurfaces, nbrackets = z.getNumbers()
             if opt.verbose:
                 print(
-                    "{} {}/{} {} {}".format(iloop, iz + 1, nvoid, nsurfaces, nbrackets)
+                    f"{iloop} {iz + 1}/{nvoid} {nsurfaces} {nbrackets}"
                 )
 
             if nsurfaces > maxsurf and nbrackets > maxbracket:
@@ -115,7 +115,7 @@ def GetVoidDef(MetaList, Surfaces, Enclosure, setting, Lev0=False):
                     z.BoundBox.ZMax * 0.1,
                 )
 
-                print("build complementary {} {}".format(iloop, iz))
+                print(f"build complementary {iloop} {iz}")
 
                 cell, CellIn = z.getVoidComplementary(Surfaces, simplify=simplifyVoid)
                 if cell is not None:

--- a/src/geouned/GEOUNED/Void/voidFunctions.py
+++ b/src/geouned/GEOUNED/Void/voidFunctions.py
@@ -89,11 +89,9 @@ def updateVoidList(offset, voidList, NestedEnclosure, sortEnclosure):
                 m.ParentEnclosureID = encl.ParentEnclosureID
                 m.EnclosureID = encl.EnclosureID
                 if sortEnclosure:
-                    m.Comments = m.Comments + "\n{}".format(encl.Comments)
+                    m.Comments = m.Comments + f"\n{encl.Comments}"
                 else:
-                    m.Comments = m.Comments + "\nVoid Enclosure #{}".format(
-                        encl.EnclosureID
-                    )
+                    m.Comments = m.Comments + f"\nVoid Enclosure #{encl.EnclosureID}"
                 icount += 1
                 newVoidList.append(m)
             ivoid += 1

--- a/src/geouned/GEOUNED/Write/AdditionalFiles.py
+++ b/src/geouned/GEOUNED/Write/AdditionalFiles.py
@@ -11,9 +11,7 @@ def commentsWrite(name, MetaList):
 def summaryWrite(name, MetaList):
 
     outfile = open(name + "_Summary.txt", "w", encoding="utf-8")
-    header = "  Cell Id{:5s}Mat Id{:6s}Density{:7s}Volume{:5s}Comments\n".format(
-        "", "", "", ""
-    )
+    header = f"  Cell Id{'':5s}Mat Id{'':6s}Density{'':7s}Volume{'':5s}Comments\n"
     outfile.write(header)
 
     for m in MetaList:

--- a/src/geouned/GEOUNED/Write/Functions.py
+++ b/src/geouned/GEOUNED/Write/Functions.py
@@ -29,7 +29,7 @@ class CardLine:
                 self.__leftspace__ -= len(data_str)
             else:
                 self.str += line + "\n"
-                line = "{}{}".format(self.tabstr, data_str)
+                line = f"{self.tabstr}{data_str}"
                 self.__leftspace__ = self.lineSize - len(line)
 
         self.str += line
@@ -81,9 +81,9 @@ class CellString:
             if lenleft == 0:
                 break
             elif icount < len(self.str):
-                newline += "\n{}".format(self.tabstr)
+                newline += f"\n{self.tabstr}"
             else:
-                newline += "\n{}{}".format(self.tabstr, self.str[init:])
+                newline += f"\n{self.tabstr}{self.str[init:]}"
                 break
 
         self.str = newline
@@ -137,9 +137,9 @@ def writeOpenMCregion(Definition, Wtype="XML"):
 def writeSequenceMCNP(Seq):
     if Seq.level == 0:
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(map(str, Seq.elements)))
+            line = f"({' '.join(map(str, Seq.elements))})"
         else:
-            line = "({})".format(":".join(map(str, Seq.elements)))
+            line = f"({':'.join(map(str, Seq.elements))})"
     else:
         terms = []
         for e in Seq.elements:
@@ -149,9 +149,9 @@ def writeSequenceMCNP(Seq):
                 terms.append(writeSequenceMCNP(e))
 
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(terms))
+            line = f"({' '.join(terms)})"
         else:
-            line = "({})".format(":".join(terms))
+            line = f"({':'.join(terms)})"
 
     return line
 
@@ -159,9 +159,9 @@ def writeSequenceMCNP(Seq):
 def writeSequenceSerpent(Seq):
     if Seq.level == 0:
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(map(str, Seq.elements)))
+            line = f"({' '.join(map(str, Seq.elements))})"
         else:
-            line = "({})".format(":".join(map(str, Seq.elements)))
+            line = f"({':'.join(map(str, Seq.elements))})"
     else:
         terms = []
         for e in Seq.elements:
@@ -171,9 +171,9 @@ def writeSequenceSerpent(Seq):
                 terms.append(writeSequenceMCNP(e))
 
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(terms))
+            line = f"({' '.join(terms)})"
         else:
-            line = "({})".format(":".join(terms))
+            line = f"({':'.join(terms)})"
 
     return line
 
@@ -181,9 +181,9 @@ def writeSequenceSerpent(Seq):
 def writeSequencePHITS(Seq):
     if Seq.level == 0:
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(map(str, Seq.elements)))
+            line = f"({' '.join(map(str, Seq.elements))})"
         else:
-            line = "({})".format(":".join(map(str, Seq.elements)))
+            line = f"({':'.join(map(str, Seq.elements))})"
     else:
         terms = []
         for e in Seq.elements:
@@ -193,9 +193,9 @@ def writeSequencePHITS(Seq):
                 terms.append(writeSequencePHITS(e))
 
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(terms))
+            line = f"({' '.join(terms)})"
         else:
-            line = "({})".format(":".join(terms))
+            line = f"({':'.join(terms)})"
 
     return line
 
@@ -203,9 +203,9 @@ def writeSequencePHITS(Seq):
 def writeSequenceOMCXML(Seq):
     if Seq.level == 0:
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(map(str, Seq.elements)))
+            line = f"({' '.join(map(str, Seq.elements))})"
         else:
-            line = "({})".format(" | ".join(map(str, Seq.elements)))
+            line = f"({' | '.join(map(str, Seq.elements))})"
     else:
         terms = []
         for e in Seq.elements:
@@ -215,23 +215,23 @@ def writeSequenceOMCXML(Seq):
                 terms.append(writeSequenceOMCXML(e))
 
         if Seq.operator == "AND":
-            line = "({})".format(" ".join(terms))
+            line = f"({' '.join(terms)})"
         else:
-            line = "({})".format(" | ".join(terms))
+            line = f"({' | '.join(terms)})"
     return line
 
 
 def writeSequenceOMCPY(Seq, prefix="S"):
 
     strSurf = lambda surf: (
-        "-{}{}".format(prefix, -surf) if surf < 0 else "+{}{}".format(prefix, surf)
+        f"-{prefix}{-surf}" if surf < 0 else f"+{prefix}{surf}"
     )
 
     if Seq.level == 0:
         if Seq.operator == "AND":
-            line = "({})".format(" & ".join(map(strSurf, Seq.elements)))
+            line = f"({' & '.join(map(strSurf, Seq.elements))})"
         else:
-            line = "({})".format(" | ".join(map(strSurf, Seq.elements)))
+            line = f"({' | '.join(map(strSurf, Seq.elements))})"
     else:
         terms = []
         for e in Seq.elements:
@@ -241,9 +241,9 @@ def writeSequenceOMCPY(Seq, prefix="S"):
                 terms.append(writeSequenceOMCPY(e))
 
         if Seq.operator == "AND":
-            line = "({})".format(" & ".join(terms))
+            line = f"({' & '.join(terms)})"
         else:
-            line = "({})".format(" | ".join(terms))
+            line = f"({' | '.join(terms)})"
     return line
 
 
@@ -450,7 +450,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 coeffs = "{:{x}}".format(D, x=nf.P_xyz)
             else:
                 OMCsurf = "XPlane"
-                coeffs = "x0={}".format(D)
+                coeffs = f"x0={D}"
 
         elif surf.Axis.isEqual(FreeCAD.Vector(0, 1, 0), tol.pln_angle):
             if outXML:
@@ -458,7 +458,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 coeffs = "{:{x}}".format(D, x=nf.P_xyz)
             else:
                 OMCsurf = "YPlane"
-                coeffs = "y0={}".format(D)
+                coeffs = f"y0={D}"
 
         elif surf.Axis.isEqual(FreeCAD.Vector(0, 0, 1), tol.pln_angle):
             if outXML:
@@ -466,7 +466,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 coeffs = "{:{x}}".format(D, x=nf.P_xyz)
             else:
                 OMCsurf = "ZPlane"
-                coeffs = "z0={}".format(D)
+                coeffs = f"z0={D}"
 
         else:
             if outXML:
@@ -476,7 +476,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 )
             else:
                 OMCsurf = "Plane"
-                coeffs = "a={},b={},c={},d={}".format(A, B, C, D)
+                coeffs = f"a={A},b={B},c={C},d={D}"
 
     elif Type == "Cylinder":
         Pos = surf.Center * 0.1
@@ -492,7 +492,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 )
             else:
                 OMCsurf = "XCylinder"
-                coeffs = "y0={},z0={},r={}".format(Pos.y, Pos.z, Rad)
+                coeffs = f"y0={Pos.y},z0={Pos.z},r={Rad}"
 
         elif isParallel(Dir, FreeCAD.Vector(0, 1, 0), tol.angle):
             if outXML:
@@ -502,7 +502,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 )
             else:
                 OMCsurf = "YCylinder"
-                coeffs = "x0={},z0={},r={}".format(Pos.x, Pos.z, Rad)
+                coeffs = f"x0={Pos.x},z0={Pos.z},r={Rad}"
 
         elif isParallel(Dir, FreeCAD.Vector(0, 0, 1), tol.angle):
             if outXML:
@@ -512,7 +512,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 )
             else:
                 OMCsurf = "ZCylinder"
-                coeffs = "x0={},y0={},r={}".format(Pos.x, Pos.y, Rad)
+                coeffs = f"x0={Pos.x},y0={Pos.y},r={Rad}"
 
         else:
             if outXML:
@@ -553,7 +553,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 )
             else:
                 OMCsurf = "XCone"
-                coeffs = "x0={},y0={},z0={},r2={}".format(Apex.x, Apex.y, Apex.z, tan2)
+                coeffs = f"x0={Apex.x},y0={Apex.y},z0={Apex.z},r2={tan2}"
 
         elif isParallel(Dir, Y_dir, tol.angle):
             if outXML:
@@ -563,7 +563,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 )
             else:
                 OMCsurf = "YCone"
-                coeffs = "x0={},y0={},z0={},r2={}".format(Apex.x, Apex.y, Apex.z, tan2)
+                coeffs = f"x0={Apex.x},y0={Apex.y},z0={Apex.z},r2={tan2}"
 
         elif isParallel(Dir, Z_dir, tol.angle):
             if outXML:
@@ -573,7 +573,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
                 )
             else:
                 OMCsurf = "ZCone"
-                coeffs = "x0={},y0={},z0={},r2={}".format(Apex.x, Apex.y, Apex.z, tan2)
+                coeffs = f"x0={Apex.x},y0={Apex.y},z0={Apex.z},r2={tan2}"
 
         else:
             if outXML:
@@ -605,7 +605,7 @@ def OpenMCSurface(Type, surf, outXML=True, quadricForm=False):
             )
         else:
             OMCsurf = "Sphere"
-            coeffs = "x0={},y0={},z0={},r={}".format(Center.x, Center.y, Center.z, Rad)
+            coeffs = f"x0={Center.x},y0={Center.y},z0={Center.z},r={Rad}"
 
     elif Type == "Torus":
         Center = surf.Center * 0.1

--- a/src/geouned/GEOUNED/Write/OpenMCFormat.py
+++ b/src/geouned/GEOUNED/Write/OpenMCFormat.py
@@ -22,7 +22,7 @@ class OpenmcInput:
         self.Materials = set()
 
     def writeXML(self, filename):
-        print("write OpenMC xml file {}".format(filename))
+        print(f"write OpenMC xml file {filename}")
         self.inpfile = open(filename, "w", encoding="utf-8")
         self.__write_xml_header__(filename)
 
@@ -62,7 +62,7 @@ class OpenmcInput:
         if cell.Material == 0:
             matName = "void"
         else:
-            matName = "{}".format(cell.Material)
+            matName = f"{cell.Material}"
 
         OMCcell = '  <cell id="{}" material="{}" name="{}" region="{}" universe="1"/>\n'.format(
             index, matName, cellName, writeOpenMCregion(cell.Definition, "XML")
@@ -88,7 +88,7 @@ class OpenmcInput:
         return
 
     def writePY(self, filename):
-        print("write OpenMC python script {}".format(filename))
+        print(f"write OpenMC python script {filename}")
 
         # get all the materials present in the model
         for cell in self.Cells:
@@ -131,11 +131,11 @@ import openmc
         matList = tuple(sorted(self.Materials))
         strMat = []
         for m in matList:
-            material = "M{} = openmc.Material(name='M{}')\n".format(m, m)
+            material = f"M{m} = openmc.Material(name='M{m}')\n"
             self.inpfile.write(material)
-            strMat.append("M{}".format(m))
+            strMat.append(f"M{m}")
 
-        collect = "materials = openmc.Materials([{}])\n".format(", ".join(strMat))
+        collect = f"materials = openmc.Materials([{', '.join(strMat)}])\n"
         self.inpfile.write(collect)
         self.inpfile.write("materials.export_to_xml()\n")
 
@@ -153,7 +153,7 @@ import openmc
         )
 
         if not boundary:
-            OMCsurf = "S{} = openmc.{}({})\n".format(surface.Index, surfType, coeffs)
+            OMCsurf = f"S{surface.Index} = openmc.{surfType}({coeffs})\n"
         else:
             OMCsurf = 'S{} = openmc.{}({}, boundary_type="vacuum")\n'.format(
                 surface.Index, surfType, coeffs
@@ -171,7 +171,7 @@ import openmc
             self.__write_py_cells__(cell)
             if cell.__id__ is None:
                 continue
-            cellNames.append("C{}".format(cell.label))
+            cellNames.append(f"C{cell.label}")
 
         geometry = (
             "\ngeometry = openmc.Geometry([{}])\ngeometry.export_to_xml()\n".format(
@@ -194,7 +194,7 @@ import openmc
                 index, cellName, writeOpenMCregion(cell.Definition, "PY")
             )
         else:
-            matName = "M{}".format(cell.Material)
+            matName = f"M{cell.Material}"
             OMCcell = 'C{} = openmc.Cell(name="{}", fill={}, region={})\n'.format(
                 index, cellName, matName, writeOpenMCregion(cell.Definition, "PY")
             )
@@ -258,7 +258,7 @@ import openmc
 
         if p.Index not in self.surfaceTable.keys():
             print(
-                "{} Surface {} not used in cell definition)".format(p.Type, p.Index),
+                f"{p.Type} Surface {p.Index} not used in cell definition)",
                 p.Surf.Axis,
                 p.Surf.Position,
             )

--- a/src/geouned/GEOUNED/Write/PHITSFormat.py
+++ b/src/geouned/GEOUNED/Write/PHITSFormat.py
@@ -57,7 +57,7 @@ class PhitsInput:
         return
 
     def writePHITS(self, filename):
-        print("write PHITS file {}".format(filename))
+        print(f"write PHITS file {filename}")
         self.inpfile = open(filename, "w", encoding="utf-8")
         self.__write_PHITS_header__(filename)
 
@@ -138,26 +138,20 @@ $ PHITSFormat Version :  0.0.2.3     06/03/2024\n""".format(
             )
         )
 
-        Information = """$
+        Information = f"""$
 $ *************************************************************
-$ Original Step file : {}
+$ Original Step file : {self.StepFile}
 $
-$ Creation Date : {}
-$ Solid Cells   : {}
-$ Total Cells   : {}
-$ Surfaces      : {}
-$ Materials     : {}
+$ Creation Date : {datetime.now()}
+$ Solid Cells   : {self.__solidCells__}
+$ Total Cells   : {self.__cells__}
+$ Surfaces      : {len(self.Surfaces)}
+$ Materials     : {len(self.__materials__)}
 $
 $ **************************************************************
 
-\n""".format(
-            self.StepFile,
-            datetime.now(),
-            self.__solidCells__,
-            self.__cells__,
-            len(self.Surfaces),
-            len(self.__materials__),
-        )
+
+"""
 
         self.inpfile.write(Header)
         self.inpfile.write(Information)
@@ -212,7 +206,7 @@ $ **************************************************************
         if cell.Material == 0:
             if cell.MatInfo == "Graveyard":
                 cell.MatInfo = "Outer void"
-                cellHeader = "{:<5d} {:<5d}  ".format(index, -1)
+                cellHeader = f"{index:<5d} {-1:<5d}  "
 
             elif cell.MatInfo == "Graveyard_in":
                 cell.MatInfo = "Inner void"
@@ -227,17 +221,15 @@ $ **************************************************************
                             index, self.voidMat[0], self.voidMat[1]
                         )
                 else:
-                    cellHeader = "{:<5d} {:<5d}  ".format(index, 0)
+                    cellHeader = f"{index:<5d} {0:<5d}  "
 
             else:
-                cellHeader = "{:<5d} {:<5d}  ".format(index, 0)
+                cellHeader = f"{index:<5d} {0:<5d}  "
 
         else:
             self.Materials.add(cell.Material)
             if self.Matfile == "" and cell.EnclosureID != 0:
-                cellHeader = "{:<5d} {:<5d} c{:<5d} ".format(
-                    index, cell.Material, cell.Material
-                )
+                cellHeader = f"{index:<5d} {cell.Material:<5d} c{cell.Material:<5d} "
             else:
                 if abs(cell.Density) < 1e-2:
                     cellHeader = "{:<5d} {:<5d} {:11.4e} ".format(
@@ -291,10 +283,10 @@ $ **************************************************************
                 eliminated_endVoidIndex = self.__cells__ + self.startCell - 3
 
                 if self.startCell == startVoidIndex - 1:
-                    inclSolidCells = "{:1s}#{}".format("", self.startCell)
+                    inclSolidCells = f"{'':1s}#{self.startCell}"
                 else:
                     for i in range(self.startCell, startVoidIndex):
-                        inclSolidCells += "{:1s}#{}".format("", i)
+                        inclSolidCells += f"{'':1s}#{i}"
 
                 if startVoidIndex == eliminated_endVoidIndex:
                     one_mervoid_str = "VOID CELL {} merged, so the auto-genarated void definition is eliminated\n"
@@ -315,7 +307,7 @@ $ **************************************************************
                             index, self.voidMat[0], self.voidMat[1]
                         )
                 else:
-                    cellHeader = "{:<5d} {:<5d}  ".format(index, 0)
+                    cellHeader = f"{index:<5d} {0:<5d}  "
 
                 phitscell = "{}{}\n{}{}\n".format(
                     cellHeader,
@@ -329,7 +321,7 @@ $ **************************************************************
                 return
 
             elif cell.MatInfo == "Graveyard":
-                cellHeader = "{:<5d} {:<5d}  ".format(index, -1)
+                cellHeader = f"{index:<5d} {-1:<5d}  "
                 cell.MatInfo = "Outer void"
 
             else:
@@ -351,9 +343,7 @@ $ **************************************************************
         else:
             self.Materials.add(cell.Material)
             if self.Matfile == "" and cell.EnclosureID != 0:
-                cellHeader = "{:<5d} {:<5d} c{:<5d} ".format(
-                    index, cell.Material, cell.Material
-                )
+                cellHeader = f"{index:<5d} {cell.Material:<5d} c{cell.Material:<5d} "
             else:
                 if abs(cell.Density) < 1e-2:
                     cellHeader = "{:<5d} {:<5d} {:11.4e} ".format(
@@ -381,7 +371,7 @@ $ **************************************************************
             PHITS_def += "\n"
             self.inpfile.write(PHITS_def)
         else:
-            print("Surface {} cannot be written in PHITS input".format(surface.Type))
+            print(f"Surface {surface.Type} cannot be written in PHITS input")
         return
 
     def __write_PHITS_source_block__(self):
@@ -413,7 +403,7 @@ $ **************************************************************
 
     def __write_PHITS__Volume_block__(self):
 
-        vol = "{:5s}reg{:5s}vol\n".format("", "")
+        vol = f"{'':5s}reg{'':5s}vol\n"
 
         startVoidIndex = self.__solidCells__ + self.startCell
         eliminated_endVoidIndex = self.__cells__ + self.startCell - 3
@@ -432,7 +422,7 @@ $ **************************************************************
                                 )
                             )
                         else:
-                            vol += "{:6s}{}{:6s}1.0\n".format("", cell.label, "")
+                            vol += f"{'':6s}{cell.label}{'':6s}1.0\n"
                     elif cell.Void:
                         if cell.label in range(
                             startVoidIndex, eliminated_endVoidIndex + 1
@@ -443,17 +433,15 @@ $ **************************************************************
                                 )
                             )
                         else:
-                            vol += "{:6s}{}{:6s}1.0\n".format("", cell.label, "")
+                            vol += f"{'':6s}{cell.label}{'':6s}1.0\n"
                     else:
-                        vol += "{:6s}{}{:6s}{:6e}\n".format(
-                            "", cell.label, "", cell.Volume * 1e-3
-                        )
+                        vol += f"{'':6s}{cell.label}{'':6s}{cell.Volume * 0.001:6e}\n"
         else:
             if self.Options["Volume"]:
                 for i, cell in enumerate(self.Cells):
                     if cell.__id__ is not None:
                         if cell.Void:
-                            vol += "{:6s}{}{:6s}1.0\n".format("", cell.label, "")
+                            vol += f"{'':6s}{cell.label}{'':6s}1.0\n"
                         else:
                             vol += "{:6s}{}{:6s}{:6e}\n".format(
                                 "", cell.label, "", cell.Volume * 1e-3
@@ -491,12 +479,12 @@ $ **************************************************************
         option = ""
         if self.Options["Volume"]:
             if not cell.Void:
-                option = "${:11s}Vol={:e} cm3\n".format("", cell.Volume * 1e-3)
+                option = f"${'':11s}Vol={cell.Volume * 0.001:e} cm3\n"
             else:
-                option = "${:11s}Vol=1.0 cm3\n".format("")
+                option = f"${'':11s}Vol=1.0 cm3\n"
 
         if self.Options["Universe"] is not None:
-            option += "{:11s}U={}\n".format("", self.Options["Universe"])
+            option += f"{'':11s}U={self.Options['Universe']}\n"
 
         return option
 
@@ -507,13 +495,13 @@ $ **************************************************************
             mComment = mComment.split("\n")
             for c in mComment:
                 if c:
-                    comment += "{:11s}${}\n".format("", c)
+                    comment += f"{'':11s}${c}\n"
 
         if cComment.strip() != "":
             cComment = cComment.strip().split("\n")
             for c in cComment:
                 if c:
-                    comment += "{:11s}${}\n".format("", c)
+                    comment += f"{'':11s}${c}\n"
         return comment
 
     def __commentLine__(self, lineComment):
@@ -523,7 +511,7 @@ $ **************************************************************
             comment = "$ \n"
             for c in lineComment:
                 if c:
-                    comment += "$ {}\n".format(c)
+                    comment += f"$ {c}\n"
             comment += "$ \n"
         return comment
 
@@ -591,7 +579,7 @@ $ **************************************************************
 
         if p.Index not in self.surfaceTable.keys():
             print(
-                "{} Surface {} not used in cell definition)".format(p.Type, p.Index),
+                f"{p.Type} Surface {p.Index} not used in cell definition)",
                 p.Surf.Axis,
                 p.Surf.Position,
             )

--- a/src/geouned/GEOUNED/Write/SerpentFormat.py
+++ b/src/geouned/GEOUNED/Write/SerpentFormat.py
@@ -89,33 +89,26 @@ class SerpentInput:
         releaseDate = GEOUNED_ReleaseDate
         freeCAD_Version = "{V[0]:}.{V[1]:}.{V[2]:}".format(V=FreeCAD.Version())
 
-        Header = """{}
+        Header = f"""{self.Title}
 %   ______ _______  _____      _     _ __   _ _______ ______  
-%  |  ____ |______ |     | ___ |     | | \  | |______ |     \ 
-%  |_____| |______ |_____|     |_____| |  \_| |______ |_____/
-% Version : {}     {}
-% FreeCAD Version : {} \n""".format(
-            self.Title, version, releaseDate, freeCAD_Version
-        )
+%  |  ____ |______ |     | ___ |     | | \\  | |______ |     \\ 
+%  |_____| |______ |_____|     |_____| |  \\_| |______ |_____/
+% Version : {version}     {releaseDate}
+% FreeCAD Version : {freeCAD_Version} 
+"""
 
-        Information = """%
+        Information = f"""%
 % *************************************************************
-% Original Step file : {}
+% Original Step file : {self.StepFile}
 %
-% Creation Date : {}
-% Solid Cells   : {}
-% Total Cells   : {}
-% Surfaces      : {}
-% Materials     : {}
+% Creation Date : {datetime.now()}
+% Solid Cells   : {self.__solidCells__}
+% Total Cells   : {self.__cells__}
+% Surfaces      : {len(self.Surfaces)}
+% Materials     : {len(self.__materials__)}
 %
-% **************************************************************\n""".format(
-            self.StepFile,
-            datetime.now(),
-            self.__solidCells__,
-            self.__cells__,
-            len(self.Surfaces),
-            len(self.__materials__),
-        )
+% **************************************************************
+"""
         self.inpfile.write(Header)
         self.inpfile.write(Information)
         return
@@ -183,7 +176,7 @@ class SerpentInput:
             Serpent_def += "\n"
             self.inpfile.write(Serpent_def)
         else:
-            print("Surface {} cannot be written in Serpent input".format(surface.Type))
+            print(f"Surface {surface.Type} cannot be written in Serpent input")
         return
 
     # No void all option in Serpent. For now remove addition of source.
@@ -197,9 +190,7 @@ class SerpentInput:
             mat.sort()
             MATCARD = ""
             for m in mat:
-                MATCARD += "mat {:<6d} {:11.4e} \n1001 1 \n".format(
-                    m, self.cell.Density
-                )
+                MATCARD += f"mat {m:<6d} {self.cell.Density:11.4e} \n1001 1 \n"
             Block = MATCARD + "% \n" + MODE
         else:
             Block = MODE
@@ -265,13 +256,13 @@ class SerpentInput:
             mComment = mComment.split("\n")
             for c in mComment:
                 if c:
-                    comment += "{:11s}%{}\n".format("", c)
+                    comment += f"{'':11s}%{c}\n"
 
         if cComment.strip() != "":
             cComment = cComment.strip().split("\n")
             for c in cComment:
                 if c:
-                    comment += "{:11s}%{}\n".format("", c)
+                    comment += f"{'':11s}%{c}\n"
         return comment
 
     def comment_line(self, lineComment):
@@ -281,7 +272,7 @@ class SerpentInput:
             comment = "% \n"
             for c in lineComment:
                 if c:
-                    comment += "% {}\n".format(c)
+                    comment += f"% {c}\n"
             comment += "% \n"
         return comment
 
@@ -350,7 +341,7 @@ class SerpentInput:
 
         if p.Index not in self.surfaceTable.keys():
             print(
-                "{} Surface {} not used in cell definition)".format(p.Type, p.Index),
+                f"{p.Type} Surface {p.Index} not used in cell definition)",
                 p.Surf.Axis,
                 p.Surf.Position,
             )

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -258,7 +258,7 @@ class CadToCsg:
                             PdEntry = True
 
             else:
-                print("bad section name : {}".format(section))
+                print(f"bad section name : {section}")
 
         if self.__dict__["geometryName"] == "":
             self.__dict__["geometryName"] = self.__dict__["stepFile"][:-4]
@@ -280,17 +280,17 @@ class CadToCsg:
             Options.setAttribute(kwrd,value)
             return
         elif kwrd not in self.__dict__.keys():
-            print("Bad entry : {}".format(kwrd))
+            print(f"Bad entry : {kwrd}")
             return
 
         if kwrd == "stepFile":
             if isinstance(value, (list, tuple)):
                 for v in value:
                     if not isinstance(v, str):
-                        print("elemt in {} list should be string".format(kwrd))
+                        print(f"elemt in {kwrd} list should be string")
                         return
             elif not isinstance(value, str):
-                print("{} should be string or tuple of strings".format(kwrd))
+                print(f"{kwrd} should be string or tuple of strings")
                 return
 
         elif kwrd == "UCARD":
@@ -299,22 +299,22 @@ class CadToCsg:
             elif value.isdigit():
                 value = int(value)
             else:
-                print("{} value should be None or integer".format(kwrd))
+                print(f"{kwrd} value should be None or integer")
                 return
         elif kwrd == "outFormat":
             if len(value) == 0:
                 return
         elif kwrd in ("geometryName", "matFile", "exportSolids"):
             if not isinstance(value, str):
-                print("{} value should be str instance".format(kwrd))
+                print(f"{kwrd} value should be str instance")
                 return
         elif kwrd in ("cellRange", "voidMat", "voidExclude"):
             if not isinstance(value, (list, tuple)):
-                print("{} value should be list or tuple".format(kwrd))
+                print(f"{kwrd} value should be list or tuple")
                 return
         elif kwrd in ("minVoidSize", "maxSurf", "maxBracket", "startCell", "startSurf"):
             if not isinstance(value, int):
-                print("{} value should be integer".format(kwrd))
+                print(f"{kwrd} value should be integer")
                 return
         elif kwrd in (
             "voidGen",
@@ -329,7 +329,7 @@ class CadToCsg:
             "sortEnclosure",
         ):
             if not isinstance(value, bool):
-                print("{} value should be boolean".format(kwrd))
+                print(f"{kwrd} value should be boolean")
                 return
 
         self.__dict__[kwrd] = value
@@ -369,14 +369,14 @@ class CadToCsg:
             MetaChunk = []
             EnclosureChunk = []
             for stp in self.stepFile:
-                print("read step file : {}".format(stp))
+                print(f"read step file : {stp}")
                 Meta, Enclosure = Load.LoadCAD(stp, self.matFile)
                 MetaChunk.append(Meta)
                 EnclosureChunk.append(Enclosure)
             MetaList = joinMetaLists(MetaChunk)
             EnclosureList = joinMetaLists(EnclosureChunk)
         else:
-            print("read step file : {}".format(self.stepFile))
+            print(f"read step file : {self.stepFile}")
             MetaList, EnclosureList = Load.LoadCAD(
                 self.stepFile, self.matFile, self.voidMat, self.compSolids
             )
@@ -511,9 +511,7 @@ class CadToCsg:
                 c.Definition.clean()
                 if type(c.Definition.elements) is bool:
                     print(
-                        "unexpected constant cell {} :{}".format(
-                            c.__id__, c.Definition.elements
-                        )
+                        f"unexpected constant cell {c.__id__} :{c.Definition.elements}"
                     )
 
         tempTime2 = datetime.now()
@@ -589,15 +587,15 @@ def DecomposeSolids(MetaList, Surfaces, UniverseBox, setting, meta):
     for i, m in enumerate(MetaList):
         if meta and m.IsEnclosure:
             continue
-        print("Decomposing solid: {}/{} ".format(i + 1, totsolid))
+        print(f"Decomposing solid: {i + 1}/{totsolid} ")
         if setting["debug"]:
             print(m.Comments)
             if not path.exists("debug"):
                 mkdir("debug")
             if m.IsEnclosure:
-                m.Solids[0].exportStep("debug/origEnclosure_{}.stp".format(i))
+                m.Solids[0].exportStep(f"debug/origEnclosure_{i}.stp")
             else:
-                m.Solids[0].exportStep("debug/origSolid_{}.stp".format(i))
+                m.Solids[0].exportStep(f"debug/origSolid_{i}.stp")
 
         comsolid, err = Decom.SplitSolid(Part.makeCompound(m.Solids), UniverseBox)
 
@@ -606,24 +604,24 @@ def DecomposeSolids(MetaList, Surfaces, UniverseBox, setting, meta):
                 mkdir("Suspicious_solids")
             if m.IsEnclosure:
                 Part.CompSolid(m.Solids).exportStep(
-                    "Suspicious_solids/Enclosure_original_{}.stp".format(i)
+                    f"Suspicious_solids/Enclosure_original_{i}.stp"
                 )
                 comsolid.exportStep(
-                    "Suspicious_solids/Enclosure_split_{}.stp".format(i)
+                    f"Suspicious_solids/Enclosure_split_{i}.stp"
                 )
             else:
                 Part.CompSolid(m.Solids).exportStep(
-                    "Suspicious_solids/Solid_original_{}.stp".format(i)
+                    f"Suspicious_solids/Solid_original_{i}.stp"
                 )
-                comsolid.exportStep("Suspicious_solids/Solid_split_{}.stp".format(i))
+                comsolid.exportStep(f"Suspicious_solids/Solid_split_{i}.stp")
 
             warningSolids.append(i)
 
         if setting["debug"]:
             if m.IsEnclosure:
-                comsolid.exportStep("debug/compEnclosure_{}.stp".format(i))
+                comsolid.exportStep(f"debug/compEnclosure_{i}.stp")
             else:
-                comsolid.exportStep("debug/compSolid_{}.stp".format(i))
+                comsolid.exportStep(f"debug/compSolid_{i}.stp")
         Surfaces.extend(
             Decom.ExtractSurfaces(comsolid, "All", UniverseBox, MakeObj=True)
         )
@@ -696,18 +694,18 @@ def printWarningSolids(warnSolids, warnEnclosures):
         lines = "Solids :\n"
         for sol in warnSolids:
             lines += "\n"
-            lines += "{}\n".format(sol.label)
-            lines += "{}\n".format(sol.Comments)
-            lines += "{}\n".format(writeMCNPCellDef(sol.Definition))
+            lines += f"{sol.label}\n"
+            lines += f"{sol.Comments}\n"
+            lines += f"{writeMCNPCellDef(sol.Definition)}\n"
         fic.write(lines)
 
     if warnEnclosures:
         lines = "Enclosures :\n"
         for sol in warnEnclosures:
             lines += "\n"
-            lines += "{}\n".format(sol.label)
-            lines += "{}\n".format(sol.Comments)
-            lines += "{}\n".format(writeMCNPCellDef(sol.Definition))
+            lines += f"{sol.label}\n"
+            lines += f"{sol.Comments}\n"
+            lines += f"{writeMCNPCellDef(sol.Definition)}\n"
 
         fic.write(lines)
 
@@ -759,12 +757,9 @@ def sortEnclosure(MetaList, MetaVoid, offSet=0):
         if m.NullCell:
             continue
         if m.IsEnclosure:
-            lineComment = """\
-##########################################################
-             ENCLOSURE {}
-##########################################################""".format(
-                m.EnclosureID
-            )
+            lineComment = f"""##########################################################
+             ENCLOSURE {m.EnclosureID}
+##########################################################"""
             mc = UF.GeounedSolid(None)
             mc.Comments = lineComment
             newMeta.append(mc)
@@ -775,12 +770,9 @@ def sortEnclosure(MetaList, MetaVoid, offSet=0):
                 e.label = icount
                 idLabel[e.__id__] = e.label
                 newMeta.append(e)
-            lineComment = """\
-##########################################################
-            END  ENCLOSURE {}
-##########################################################""".format(
-                m.EnclosureID
-            )
+            lineComment = f"""##########################################################
+            END  ENCLOSURE {m.EnclosureID}
+##########################################################"""
             mc = UF.GeounedSolid(None)
             mc.Comments = lineComment
             newMeta.append(mc)


### PR DESCRIPTION
This PR replaces all the ```.format``` methods of string manipulkation with f strings.

f strings produce the same output but are

- more readable as variable is inline
- more concise
    - shorter lines 
    - less lines (this PR reduces code base by 79 lines)
- faster

f strings are supported by python 3.6 and above. Seeing as the package already requests python 3.8 or above this change is compatible
 