### PR TITLE
Quicker tests for ci

### DIFF
--- a/src/geouned/GEOReverse/Modules/Parser/parser.py
+++ b/src/geouned/GEOReverse/Modules/Parser/parser.py
@@ -667,9 +667,7 @@ class Card(object):
                             else:
                                 # there is no proper place to wrap.
                                 self.print_debug("Cannot wrap line " + repr(i), "")
-                                warnings.warn(
-                                    f"Cannot wrap card on line {self.pos}"
-                                )
+                                warnings.warn(f"Cannot wrap card on line {self.pos}")
                                 break
                         else:
                             # input i fits to one line. Do nothing.

--- a/src/geouned/GEOReverse/Modules/buildCAD.py
+++ b/src/geouned/GEOReverse/Modules/buildCAD.py
@@ -106,9 +106,7 @@ def BuildUniverse(
     Ustart, levelMax = startInfo
     Universe = AllUniverses[Ustart]
 
-    print(
-        f"Build Universe {ContainerCell.FILL} in container cell {ContainerCell.name}"
-    )
+    print(f"Build Universe {ContainerCell.FILL} in container cell {ContainerCell.name}")
     fails = []
     for NTcell in Universe.values():
         if duplicate:

--- a/src/geouned/GEOUNED/Void/Void.py
+++ b/src/geouned/GEOUNED/Void/Void.py
@@ -93,9 +93,7 @@ def GetVoidDef(MetaList, Surfaces, Enclosure, setting, Lev0=False):
         for iz, z in enumerate(Initial):
             nsurfaces, nbrackets = z.getNumbers()
             if opt.verbose:
-                print(
-                    f"{iloop} {iz + 1}/{nvoid} {nsurfaces} {nbrackets}"
-                )
+                print(f"{iloop} {iz + 1}/{nvoid} {nsurfaces} {nbrackets}")
 
             if nsurfaces > maxsurf and nbrackets > maxbracket:
                 newspace = z.Split(minSize)

--- a/src/geouned/GEOUNED/Write/Functions.py
+++ b/src/geouned/GEOUNED/Write/Functions.py
@@ -223,9 +223,7 @@ def writeSequenceOMCXML(Seq):
 
 def writeSequenceOMCPY(Seq, prefix="S"):
 
-    strSurf = lambda surf: (
-        f"-{prefix}{-surf}" if surf < 0 else f"+{prefix}{surf}"
-    )
+    strSurf = lambda surf: (f"-{prefix}{-surf}" if surf < 0 else f"+{prefix}{surf}")
 
     if Seq.level == 0:
         if Seq.operator == "AND":

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -613,9 +613,7 @@ def DecomposeSolids(MetaList, Surfaces, UniverseBox, setting, meta):
                 Part.CompSolid(m.Solids).exportStep(
                     f"Suspicious_solids/Enclosure_original_{i}.stp"
                 )
-                comsolid.exportStep(
-                    f"Suspicious_solids/Enclosure_split_{i}.stp"
-                )
+                comsolid.exportStep(f"Suspicious_solids/Enclosure_split_{i}.stp")
             else:
                 Part.CompSolid(m.Solids).exportStep(
                     f"Suspicious_solids/Solid_original_{i}.stp"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -6,7 +7,11 @@ from geouned import CadToCsg
 
 path_to_cad = Path("testing/inputSTEP")
 step_files = list(path_to_cad.rglob("*.stp")) + list(path_to_cad.rglob("*.step"))
-
+# removing two geometries that are particularly slow to convert from CI testing
+# these two geometries remain in the test suite for locally testing
+if os.getenv("GITHUB_ACTIONS"):
+    step_files.remove(Path('testing/inputSTEP/large/SCDR.stp'))
+    step_files.remove(Path('testing/inputSTEP/large/Triangle.stp'))
 
 @pytest.mark.parametrize("input_step_file", step_files)
 def test_conversion(input_step_file):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -10,8 +10,9 @@ step_files = list(path_to_cad.rglob("*.stp")) + list(path_to_cad.rglob("*.step")
 # removing two geometries that are particularly slow to convert from CI testing
 # these two geometries remain in the test suite for locally testing
 if os.getenv("GITHUB_ACTIONS"):
-    step_files.remove(Path('testing/inputSTEP/large/SCDR.stp'))
-    step_files.remove(Path('testing/inputSTEP/large/Triangle.stp'))
+    step_files.remove(Path("testing/inputSTEP/large/SCDR.stp"))
+    step_files.remove(Path("testing/inputSTEP/large/Triangle.stp"))
+
 
 @pytest.mark.parametrize("input_step_file", step_files)
 def test_conversion(input_step_file):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -38,7 +38,8 @@ step_files.remove(Path("testing/inputSTEP/DoubleCylinder/placa.stp"))
 # removing geometries that are particularly slow to convert from CI testing
 # these geometries remain in the test suite for locally testing
 if os.getenv("GITHUB_ACTIONS"):
-    step_files.remove(Path('testing/inputSTEP/large/Triangle.stp'))
+    step_files.remove(Path("testing/inputSTEP/large/Triangle.stp"))
+
 
 @pytest.mark.skipif(
     sys.platform in ["win32", "darwin"],

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -35,6 +35,10 @@ step_files.remove(Path("testing/inputSTEP/DoubleCylinder/placa3.step"))
 step_files.remove(Path("testing/inputSTEP/DoubleCylinder/placa.stp"))
 # this face2.stp crashes when loading the geometry.xml
 
+# removing geometries that are particularly slow to convert from CI testing
+# these geometries remain in the test suite for locally testing
+if os.getenv("GITHUB_ACTIONS"):
+    step_files.remove(Path('testing/inputSTEP/large/Triangle.stp'))
 
 @pytest.mark.skipif(
     sys.platform in ["win32", "darwin"],
@@ -84,7 +88,7 @@ def test_transport(input_step_file):
     if os.getenv("GITHUB_ACTIONS"):
         settings.particles = 100_000
     else:
-        settings.particles = 10_000_000
+        settings.particles = 1_000_000
     settings.run_mode = "fixed source"
     settings.source = source
     model = openmc.Model(geometry, materials, settings)

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -31,19 +31,24 @@ openmc.config["cross_sections"] = Path("cross_sections.xml").resolve()
 
 path_to_cad = Path("testing/inputSTEP")
 step_files = list(path_to_cad.rglob("*.stp")) + list(path_to_cad.rglob("*.step"))
+# this file is removed as it fails the test. An issue has been raised to track
 step_files.remove(Path("testing/inputSTEP/Misc/rails.stp"))
-# # this checks if the tests are being run a github action runner or not
+# this checks if the tests are being run a github action runner or not
 if os.getenv("GITHUB_ACTIONS"):
     # reduced samples as github action runners have 2 threads and more samples
     # is not needed for the smaller models tested. This allows the CI to
     # quickly test the smaller models
     samples = 4_000_000
     rel_tol = 0.05
+    # removing two geometries that are particularly slow to convert from CI testing
+    # these two geometries remain in the test suite for locally testing
+    step_files.remove(Path('testing/inputSTEP/large/SCDR.stp'))
+    step_files.remove(Path('testing/inputSTEP/large/Triangle.stp'))
 else:
     # samples for local run can be larger as threads is likely to be larger
-    samples = 400_000_000
+    samples = 40_000_000
     # acceptable tolerance can also be smaller
-    rel_tol = 0.01
+    rel_tol = 0.04
 
 
 @pytest.mark.skipif(

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -42,8 +42,8 @@ if os.getenv("GITHUB_ACTIONS"):
     rel_tol = 0.05
     # removing two geometries that are particularly slow to convert from CI testing
     # these two geometries remain in the test suite for locally testing
-    step_files.remove(Path('testing/inputSTEP/large/SCDR.stp'))
-    step_files.remove(Path('testing/inputSTEP/large/Triangle.stp'))
+    step_files.remove(Path("testing/inputSTEP/large/SCDR.stp"))
+    step_files.remove(Path("testing/inputSTEP/large/Triangle.stp"))
 else:
     # samples for local run can be larger as threads is likely to be larger
     samples = 40_000_000


### PR DESCRIPTION
The conversion tests take 93 seconds locally but the majority of that is just for two of the geometries.

I think we can remove these two from the CI testing and keep them in the locally testing.

This would speed up the CI considerably as these large geometries are also the slowest for transport and volume calcs as well

Ideally we would have stp files designed to test the various different conversion challenges.

Here are all the timings for the CI test_convert script.
```
=========================================================== slowest durations ============================================================
30.04s call     tests/test_convert.py::test_conversion[input_step_file24]
24.68s call     tests/test_convert.py::test_conversion[input_step_file25]
7.97s call     tests/test_convert.py::test_conversion[input_step_file31]
7.73s call     tests/test_convert.py::test_conversion[input_step_file16]
2.59s call     tests/test_convert.py::test_conversion[input_step_file8]
2.32s call     tests/test_convert.py::test_conversion[input_step_file48]
2.16s call     tests/test_convert.py::test_conversion[input_step_file2]
1.89s call     tests/test_convert.py::test_conversion[input_step_file19]
1.81s call     tests/test_convert.py::test_conversion[input_step_file49]
1.36s call     tests/test_convert.py::test_conversion[input_step_file35]
1.20s call     tests/test_convert.py::test_conversion[input_step_file36]
1.07s call     tests/test_convert.py::test_conversion[input_step_file50]
0.68s call     tests/test_convert.py::test_conversion[input_step_file17]
0.67s call     tests/test_convert.py::test_conversion[input_step_file5]
0.60s call     tests/test_convert.py::test_conversion[input_step_file6]
0.57s call     tests/test_convert.py::test_conversion[input_step_file3]
0.57s call     tests/test_convert.py::test_conversion[input_step_file51]
0.48s call     tests/test_convert.py::test_conversion[input_step_file11]
0.46s call     tests/test_convert.py::test_conversion[input_step_file10]
0.37s call     tests/test_convert.py::test_conversion[input_step_file20]
0.33s call     tests/test_convert.py::test_conversion[input_step_file33]
0.26s call     tests/test_convert.py::test_conversion[input_step_file45]
0.25s call     tests/test_convert.py::test_conversion[input_step_file14]
0.22s call     tests/test_convert.py::test_conversion[input_step_file7]
0.22s call     tests/test_convert.py::test_conversion[input_step_file38]
0.21s call     tests/test_convert.py::test_conversion[input_step_file27]
0.20s call     tests/test_convert.py::test_conversion[input_step_file41]
0.17s call     tests/test_convert.py::test_conversion[input_step_file0]
0.15s call     tests/test_convert.py::test_conversion[input_step_file47]
0.15s call     tests/test_convert.py::test_conversion[input_step_file9]
0.14s call     tests/test_convert.py::test_conversion[input_step_file4]
0.14s call     tests/test_convert.py::test_conversion[input_step_file1]
0.13s call     tests/test_convert.py::test_conversion[input_step_file23]
0.13s call     tests/test_convert.py::test_conversion[input_step_file28]
0.13s call     tests/test_convert.py::test_conversion[input_step_file18]
0.12s call     tests/test_convert.py::test_conversion[input_step_file15]
0.11s call     tests/test_convert.py::test_conversion[input_step_file44]
0.10s call     tests/test_convert.py::test_conversion[input_step_file30]
0.10s call     tests/test_convert.py::test_conversion[input_step_file21]
0.09s call     tests/test_convert.py::test_conversion[input_step_file40]
0.09s call     tests/test_convert.py::test_conversion[input_step_file34]
0.09s call     tests/test_convert.py::test_conversion[input_step_file43]
0.09s call     tests/test_convert.py::test_conversion[input_step_file13]
0.08s call     tests/test_convert.py::test_conversion[input_step_file46]
0.06s call     tests/test_convert.py::test_conversion[input_step_file26]
0.06s call     tests/test_convert.py::test_conversion[input_step_file12]
0.05s call     tests/test_convert.py::test_conversion[input_step_file39]
0.05s call     tests/test_convert.py::test_conversion[input_step_file42]
0.04s call     tests/test_convert.py::test_conversion[input_step_file29]
0.04s call     tests/test_convert.py::test_conversion[input_step_file22]
0.03s call     tests/test_convert.py::test_conversion[input_step_file37]
0.01s call     tests/test_convert.py::test_conversion[input_step_file32]

(104 durations < 0.005s hidden.  Use -vv to show these durations.)
===================================================== 52 passed in 93.42s (0:01:33) ======================================================
```