### PR TITLE
passing specific args instead of class dict

### DIFF
--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -84,13 +84,13 @@ def get_id(face_in, Surfaces):
     return 0
 
 
-def translate(meta_list, surfaces, universe_box, setting):
+def translate(meta_list, surfaces, universe_box, debug):
     tot_solid = len(meta_list)
     for i, m in enumerate(meta_list):
         if m.IsEnclosure:
             continue
         print(f"Decomposing solid: {i}/{tot_solid} ")
-        if setting["debug"]:
+        if debug:
             print(m.Comments)
             if m.IsEnclosure:
                 m.Solids[0].exportStep(f"origEnclosure_{i}.stp")

--- a/src/geouned/GEOUNED/Write/MCNPFormat.py
+++ b/src/geouned/GEOUNED/Write/MCNPFormat.py
@@ -14,12 +14,14 @@ from .Functions import CardLine, mcnp_surface, change_surf_sign, write_mcnp_cell
 
 
 class McnpInput:
-    def __init__(self, Meta, Surfaces, setting):
-        self.Title = setting["title"]
-        self.VolSDEF = setting["volSDEF"]
-        self.VolCARD = setting["volCARD"]
-        self.U0CARD = setting["UCARD"]
-        self.dummyMat = setting["dummyMat"]
+    def __init__(
+        self, Meta, Surfaces, stepFile, title, volSDEF, volCARD, UCARD, dummyMat
+    ):
+        self.Title = title
+        self.VolSDEF = volSDEF
+        self.VolCARD = volCARD
+        self.U0CARD = UCARD
+        self.dummyMat = dummyMat
         self.Cells = Meta
         self.Options = {
             "Volume": self.VolCARD,
@@ -28,7 +30,7 @@ class McnpInput:
         }
         self.part = "P"
 
-        self.StepFile = setting["stepFile"]
+        self.StepFile = stepFile
         if isinstance(self.StepFile, (tuple, list)):
             self.StepFile = "; ".join(self.StepFile)
 

--- a/src/geouned/GEOUNED/Write/PHITSFormat.py
+++ b/src/geouned/GEOUNED/Write/PHITSFormat.py
@@ -29,19 +29,32 @@ from ..Write.Functions import (
 
 
 class PhitsInput:
-    def __init__(self, Meta, Surfaces, setting):
-        self.Title = setting["title"]
-        self.VolSDEF = setting["volSDEF"]
-        self.VolCARD = setting["volCARD"]
-        self.U0CARD = setting["UCARD"]
-        self.DummyMat = setting["dummyMat"]
-        self.Matfile = setting["matFile"]
-        self.voidMat = setting["voidMat"]
-        self.startCell = setting["startCell"]
+    def __init__(
+        self,
+        Meta,
+        Surfaces,
+        title,
+        volSDEF,
+        volCARD,
+        UCARD,
+        dummyMat,
+        matFile,
+        voidMat,
+        startCell,
+        stepFile,
+    ):
+        self.Title = title
+        self.VolSDEF = volSDEF
+        self.VolCARD = volCARD
+        self.U0CARD = UCARD
+        self.DummyMat = dummyMat
+        self.Matfile = matFile
+        self.voidMat = voidMat
+        self.startCell = startCell
         self.Cells = Meta
         self.Options = {"Volume": self.VolCARD, "Universe": self.U0CARD}
 
-        self.StepFile = setting["stepFile"]
+        self.StepFile = stepFile
         if isinstance(self.StepFile, (tuple, list)):
             self.StepFile = "; ".join(self.StepFile)
 

--- a/src/geouned/GEOUNED/Write/SerpentFormat.py
+++ b/src/geouned/GEOUNED/Write/SerpentFormat.py
@@ -13,12 +13,14 @@ from .Functions import serpent_surface, change_surf_sign, write_serpent_cell_def
 
 
 class SerpentInput:
-    def __init__(self, Meta, Surfaces, setting):
-        self.Title = setting["title"]
-        self.VolSDEF = setting["volSDEF"]
-        self.VolCARD = setting["volCARD"]
-        self.U0CARD = setting["UCARD"]
-        self.dummyMat = setting["dummyMat"]
+    def __init__(
+        self, Meta, Surfaces, title, volSDEF, volCARD, UCARD, dummyMat, stepFile
+    ):
+        self.Title = title
+        self.VolSDEF = volSDEF
+        self.VolCARD = volCARD
+        self.U0CARD = UCARD
+        self.dummyMat = dummyMat
         self.Cells = Meta
         self.Options = {
             "Volume": self.VolCARD,
@@ -27,7 +29,7 @@ class SerpentInput:
         }
         self.part = "p"
 
-        self.StepFile = setting["stepFile"]
+        self.StepFile = stepFile
         if isinstance(self.StepFile, (tuple, list)):
             self.StepFile = "; ".join(self.StepFile)
 

--- a/src/geouned/GEOUNED/Write/WriteFiles.py
+++ b/src/geouned/GEOUNED/Write/WriteFiles.py
@@ -5,27 +5,43 @@ from .PHITSFormat import PhitsInput
 from .SerpentFormat import SerpentInput
 
 
-def write_geometry(UniverseBox, MetaList, Surfaces, code_setting):
-
-    baseName = code_setting["geometryName"]
+def write_geometry(
+    UniverseBox,
+    MetaList,
+    Surfaces,
+    stepFile,
+    title,
+    volSDEF,
+    volCARD,
+    UCARD,
+    dummyMat,
+    geometryName,
+    outFormat,
+    cellCommentFile,
+    cellSummaryFile,
+    voidGen,
+    matFile,
+    voidMat,
+    startCell,
+):
 
     # Currently there are two was of setting outFormat (via a .set method and
     # a class attribute. Once we have a single method then move this validating
     # input code to the attribute @setter
     supported_mc_codes = ("mcnp", "openMC_XML", "openMC_PY", "serpent", "phits")
-    for out_format in code_setting["outFormat"]:
+    for out_format in outFormat:
         if out_format not in supported_mc_codes:
             msg = f"outFormat {out_format} not in supported MC codes ({supported_mc_codes})"
             raise ValueError(msg)
 
     # write cells comments in file
-    if code_setting["cellCommentFile"]:
-        OutFiles.comments_write(baseName, MetaList)
-    if code_setting["cellSummaryFile"]:
-        OutFiles.summary_write(baseName, MetaList)
+    if cellCommentFile:
+        OutFiles.comments_write(geometryName, MetaList)
+    if cellSummaryFile:
+        OutFiles.summary_write(geometryName, MetaList)
 
-    if "mcnp" in code_setting["outFormat"]:
-        mcnpFilename = baseName + ".mcnp"
+    if "mcnp" in outFormat:
+        mcnpFilename = geometryName + ".mcnp"
         outBox = (
             UniverseBox.XMin,
             UniverseBox.XMax,
@@ -34,31 +50,30 @@ def write_geometry(UniverseBox, MetaList, Surfaces, code_setting):
             UniverseBox.ZMin,
             UniverseBox.ZMax,
         )
-        if code_setting["voidGen"]:
+        if voidGen:
             outSphere = (Surfaces["Sph"][-1].Index, Surfaces["Sph"][-1].Surf.Radius)
         else:
             outSphere = None
 
-        MCNPfile = McnpInput(MetaList, Surfaces, code_setting)
+        MCNPfile = McnpInput(
+            MetaList, Surfaces, stepFile, title, volSDEF, volCARD, UCARD, dummyMat
+        )
         MCNPfile.set_sdef((outSphere, outBox))
         MCNPfile.write_input(mcnpFilename)
 
-    if (
-        "openMC_XML" in code_setting["outFormat"]
-        or "openMC_PY" in code_setting["outFormat"]
-    ):
+    if "openMC_XML" in outFormat or "openMC_PY" in outFormat:
         OMCFile = OpenmcInput(MetaList, Surfaces)
 
-    if "openMC_XML" in code_setting["outFormat"]:
-        omcFilename = baseName + ".xml"
+    if "openMC_XML" in outFormat:
+        omcFilename = geometryName + ".xml"
         OMCFile.write_xml(omcFilename)
 
-    if "openMC_PY" in code_setting["outFormat"]:
-        omcFilename = baseName + ".py"
+    if "openMC_PY" in outFormat:
+        omcFilename = geometryName + ".py"
         OMCFile.write_py(omcFilename)
 
-    if "serpent" in code_setting["outFormat"]:
-        serpentFilename = baseName + ".serp"
+    if "serpent" in outFormat:
+        serpentFilename = geometryName + ".serp"
         outBox = (
             UniverseBox.XMin,
             UniverseBox.XMax,
@@ -67,17 +82,19 @@ def write_geometry(UniverseBox, MetaList, Surfaces, code_setting):
             UniverseBox.ZMin,
             UniverseBox.ZMax,
         )
-        if code_setting["voidGen"]:
+        if voidGen:
             outSphere = (Surfaces["Sph"][-1].Index, Surfaces["Sph"][-1].Surf.Radius)
         else:
             outSphere = None
 
-        Serpentfile = SerpentInput(MetaList, Surfaces, code_setting)
+        Serpentfile = SerpentInput(
+            MetaList, Surfaces, title, volSDEF, volCARD, UCARD, dummyMat, stepFile
+        )
         # Serpentfile.set_sdef((outSphere,outBox))
         Serpentfile.write_input(serpentFilename)
 
-    if "phits" in code_setting["outFormat"]:
-        phitsFilename = baseName + ".inp"
+    if "phits" in outFormat:
+        phitsFilename = geometryName + ".inp"
         PHITS_outBox = (
             UniverseBox.XMin,
             UniverseBox.XMax,
@@ -86,7 +103,7 @@ def write_geometry(UniverseBox, MetaList, Surfaces, code_setting):
             UniverseBox.ZMin,
             UniverseBox.ZMax,
         )
-        if code_setting["voidGen"]:
+        if voidGen:
             PHITS_outSphere = (
                 Surfaces["Sph"][-1].Index,
                 Surfaces["Sph"][-1].Surf.Radius,
@@ -94,6 +111,18 @@ def write_geometry(UniverseBox, MetaList, Surfaces, code_setting):
         else:
             PHITS_outSphere = None
 
-        PHITSfile = PhitsInput(MetaList, Surfaces, code_setting)
+        PHITSfile = PhitsInput(
+            MetaList,
+            Surfaces,
+            title,
+            volSDEF,
+            volCARD,
+            UCARD,
+            dummyMat,
+            matFile,
+            voidMat,
+            startCell,
+            stepFile,
+        )
         # PHITSfile.setSDEF_PHITS((PHITS_outSphere,PHITS_outBox))
         PHITSfile.write_phits(phitsFilename)


### PR DESCRIPTION
Currently we pass a self.__dict__ around to all the functions called.

This makes it difficult to know what functions need what data

knowing what functions need what data helps with a refactoring

while this is less concise than passing the whole class dictionary around it means we can see what is used where.

This PR is just a bare bones removal of the passing of the entire class dict

This makes it easier to create unit tests for individual function. Previously this would be difficult as one would have to make a complete CadToCsg class and pass that in as an argument

this large number of args passed from the class to the function suggests that the fucntion should be a class method instead. So we can follow this up with moving the function to the class, but first I'm keen to make all the information flow around the code clear