### PR TITLE
added missing package to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
     "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+  "numpy"
+]
 
 [project.urls]
 Homepage = "https://github.com/GEOUNED-org"


### PR DESCRIPTION
I noticed that this file src/geouned/GEOUNED/Utils/Functions.py imports numpy but we have not got numpy in the pyprojects.

This PR adds numpy to the dependencies so that pip installing it brings in the needed dependencies