### PR TITLE
Fixing logger commands

### DIFF
--- a/src/geouned/GEOUNED/Conversion/CellDefinition.py
+++ b/src/geouned/GEOUNED/Conversion/CellDefinition.py
@@ -351,7 +351,7 @@ def gen_plane_cylinder_old(face, solid):
     for i, face2 in enumerate(solid.Faces):
         if face2.Area < tol.min_area:
             logger.warning(
-                f"surface {str(surf)}  removed from cell definition. Face area < Min area ({face2.Area} < {tol.min_area})"
+                f"surface {str(surf)} removed from cell definition. Face area < Min area ({face2.Area} < {tol.min_area})"
             )
             continue
         if str(face2.Surface) == "<Cylinder object>" and not (face2.isEqual(face)):
@@ -756,7 +756,7 @@ def cellDef(meta_obj, surfaces, universe_box):
             surface_type = str(face.Surface)
             if abs(face.Area) < tol.min_area:
                 logger.warning(
-                    f"{surface_type} surface removed from cell definition. Face area < Min area ({face.Area} < {tol.min_area}) "
+                    f"{surface_type} surface removed from cell definition. Face area < Min area ({face.Area} < {tol.min_area})"
                 )
                 continue
             if face.Area < 0:
@@ -924,7 +924,7 @@ def cellDef(meta_obj, surfaces, universe_box):
                         surf_obj.append(face)
                 else:
                     logger.info(
-                        "Only Torus with axis along X, Y , Z axis can be reproduced"
+                        "Only Torus with axis along X, Y, Z axis can be reproduced"
                     )
             else:
                 id = get_id(face.Surface, surfaces)
@@ -933,7 +933,7 @@ def cellDef(meta_obj, surfaces, universe_box):
 
                 surf = face
                 if id == 0:
-                    logger.warning(f" {surface_type}, not found in surface list")
+                    logger.warning(f"{surface_type} not found in surface list")
                     if surface_type == "<Plane object>":
                         dim1 = face.ParameterRange[1] - face.ParameterRange[0]
                         dim2 = face.ParameterRange[3] - face.ParameterRange[2]

--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -93,7 +93,7 @@ def translate(meta_list, surfaces, universe_box, setting):
     for i, m in enumerate(meta_list):
         if m.IsEnclosure:
             continue
-        logger.info(f"Decomposing solid: {i}/{tot_solid} ")
+        logger.info(f"Decomposing solid: {i}/{tot_solid}")
         if setting["debug"]:
             logger.info(m.Comments)
             if m.IsEnclosure:

--- a/src/geouned/GEOUNED/Decompose/Decom_one.py
+++ b/src/geouned/GEOUNED/Decompose/Decom_one.py
@@ -490,7 +490,7 @@ def gen_plane_cylinder(face, solid):
             Uval_str_cl.append(num_str1)
 
     if len(Uval_str_cl) < 2:
-        logger.info("gen_plane_cylinder : Uval_str_cl should no be void ")
+        logger.info("gen_plane_cylinder : Uval_str_cl should no be void")
         return None
 
     face_index_2 = [face_index[0], face_index[0]]
@@ -611,7 +611,7 @@ def gen_plane_cone(face, solid):
             Uval_str_cl.append(num_str1)
 
     if len(Uval_str_cl) < 2:
-        logger.info("gen_plane_cone : Uval_str_cl should no be void ")
+        logger.info("gen_plane_cone : Uval_str_cl should no be void")
         return None
 
     face_index_2 = [face_index[0], face_index[0]]
@@ -935,9 +935,7 @@ def split_2nd_order(Solids, universe_box):
                                 break
                         except:
                             logger.info(
-                                "Failed split base with {} surface".format(
-                                    s.shape.Faces[0].Surface
-                                )
+                                "Failed split base with {s.shape.Faces[0].Surface} surface"
                             )
                             err += 2
 
@@ -1002,9 +1000,8 @@ def remove_solids(Solids):
     Solids_Clean = []
     for solid in Solids:
         if solid.Volume <= Vol_tol:
-            logger.info(
-                "Warning: remove_solids degenerated solids are produced",
-                solid.Volume,
+            logger.warning(
+                f"remove_solids degenerated solids are produced {solid.Volume}"
             )
             err = 2
             continue
@@ -1032,9 +1029,8 @@ def split_component(solidShape, universe_box):
     Pieces = []
     for part in split:
         if part.Volume <= 1e-10:
-            logger.info(
-                "Warning: split_component degenerated solids are produced",
-                part.Volume,
+            logger.warning(
+                f"split_component degenerated solids are produced {part.Volume}",
             )
             err += 2
             continue

--- a/src/geouned/GEOUNED/Decompose/Decom_one.py
+++ b/src/geouned/GEOUNED/Decompose/Decom_one.py
@@ -1042,7 +1042,7 @@ def split_component(solidShape, universe_box):
     Volch = (Volini - Volend) / Volini
 
     if abs(Volch) > 1e-2:  # 1% of Volume change
-        logger.info(f"Warning: Volume has changed after decomposition: {Volch:11.4E}")
+        logger.warning(f"Volume has changed after decomposition: {Volch:11.4E}")
         err += 4
 
     return comsolid, err

--- a/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
@@ -179,7 +179,9 @@ def check_enclosure(freecad_doc, enclosure_list):
 
     if temp_list:
         stop = True
-        logger.info("One or more nested enclosure labels in CAD solid tree view/structure tree do not have any CAD solid.")
+        logger.info(
+            "One or more nested enclosure labels in CAD solid tree view/structure tree do not have any CAD solid."
+        )
         logger.info("Each nested enclosure must have only one solid. Code STOPS.")
         logger.info("List of problematic nested enclosure labels:")
 

--- a/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadFunctions.py
@@ -179,11 +179,10 @@ def check_enclosure(freecad_doc, enclosure_list):
 
     if temp_list:
         stop = True
-        logger.info(
-            "One or more nested enclosure labels in CAD solid tree view/structure tree do not have any CAD solid.\n",
-            "Each nested enclosure must have only one solid.\nCode STOPS.",
-            "\nList of problematic nested enclosure labels:",
-        )
+        logger.info("One or more nested enclosure labels in CAD solid tree view/structure tree do not have any CAD solid.")
+        logger.info("Each nested enclosure must have only one solid. Code STOPS.")
+        logger.info("List of problematic nested enclosure labels:")
+
         for elem in temp_list:
             logger.info(elem.EnclosureID)
 
@@ -209,7 +208,7 @@ def check_enclosure(freecad_doc, enclosure_list):
         logger.info('"0" cannot be label on child Enclosure')
     if 0 not in pid_set:
         stop = True
-        logger.info(' "0" should parent label of most external enclosure(s)')
+        logger.info('"0" should parent label of most external enclosure(s)')
     if repeated_id:
         stop = True
         logger.info("Child label cannot be repeated.\nRepeated labels :")
@@ -274,13 +273,13 @@ def check_enclosure(freecad_doc, enclosure_list):
 
     if not_embedded:
         stop = True
-        logger.info(" Following enclosures are not fully embedded in Parent enclosure")
+        logger.info("Following enclosures are not fully embedded in Parent enclosure")
         for elemt in not_embedded:
             logger.info(f"{elemt[0]}_{elemt[1]}")
 
     if overlap:
         stop = True
-        logger.info(" Following enclosures overlapping ")
+        logger.info("Following enclosures overlapping ")
         for elemt in overlap:
             logger.info(f"{elemt[0]}_{elemt[1]}")
 

--- a/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
@@ -158,7 +158,7 @@ def load_cad(filename, mat_filename, default_mat=[], comp_solids=True):
                                 )
                                 missing_mat.add(mat_label)
                     else:
-                        # logger.info('Warning : No material label associated to solid {}.\nDefault material used instead.'.format(comment))
+                        # logger.warning('No material label associated to solid {}.\nDefault material used instead.'.format(comment))
                         if default_mat:
                             meta_list[i_solid].set_material(*default_mat)
                     if tempre_dil:

--- a/src/geouned/GEOUNED/Utils/BooleanSolids.py
+++ b/src/geouned/GEOUNED/Utils/BooleanSolids.py
@@ -216,7 +216,7 @@ class ConstraintTable(dict):
                 falseVal = Seq.evaluate(falseSet)
                 return falseVal if type(falseVal) is bool else None
             else:
-                logger.info("Bad trouble surfaces {} is on none side of the box!!")
+                logger.info("Bad trouble surfaces is on none side of the box!!")
                 return False
 
 

--- a/src/geouned/GEOUNED/Utils/Functions.py
+++ b/src/geouned/GEOUNED/Utils/Functions.py
@@ -213,7 +213,7 @@ class GeounedSolid:
                         "Failed solid1.distToshape(solid2), try with inverted solids"
                     )
                     distShape = sol2.distToShape(sol1)[0]
-                    logger.info("inverted disToShape OK", distShape)
+                    logger.info(f"inverted disToShape OK {distShape}")
                 dist = min(dist, distShape)
                 if dist == 0:
                     break
@@ -402,7 +402,7 @@ class SurfacesDict(dict):
 
     def __str__(self):
         for key in self.keys():
-            logger.info(key, self[key])
+            logger.info(f"{key}, {self[key]}")
         return ""
 
     def get_surface(self, index):

--- a/src/geouned/GEOUNED/Utils/Geometry_GU.py
+++ b/src/geouned/GEOUNED/Utils/Geometry_GU.py
@@ -301,7 +301,7 @@ def define_surface(face, plane3Pts):
     elif kind_surf == "<Toroid object>":
         Surf_GU = TorusGu(face)
     else:
-        logger.info("bad Surface type", kind_surf)
+        logger.info(f"bad Surface type {kind_surf}")
         Surf_GU = None
     return Surf_GU
 

--- a/src/geouned/GEOUNED/Void/Void.py
+++ b/src/geouned/GEOUNED/Void/Void.py
@@ -51,7 +51,7 @@ def void_generation(MetaList, EnclosureList, Surfaces, UniverseBox, setting, ini
     # Perform enclosure void
     # Loop until the lowest enclosure level
 
-    for i, Level in enumerate(tqdm(NestedEnclosure, desc="void generation")):
+    for i, Level in enumerate(tqdm(NestedEnclosure, desc="Void generation")):
 
         logger.info("Build Void highest enclosure")
         for j, encl in enumerate(Level):

--- a/src/geouned/GEOUNED/Write/MCNPFormat.py
+++ b/src/geouned/GEOUNED/Write/MCNPFormat.py
@@ -333,9 +333,7 @@ C **************************************************************
 
         if p.Index not in self.surfaceTable.keys():
             logger.info(
-                f"{p.Type} Surface {p.Index} not used in cell definition)",
-                p.Surf.Axis,
-                p.Surf.Position,
+                f"{p.Type} Surface {p.Index} not used in cell definition) {p.Surf.Axis} {p.Surf.Position}"
             )
             return
 

--- a/src/geouned/GEOUNED/Write/PHITSFormat.py
+++ b/src/geouned/GEOUNED/Write/PHITSFormat.py
@@ -429,7 +429,7 @@ $ **************************************************************
                             startVoidIndex, eliminated_endVoidIndex + 1
                         ):
                             logger.info(
-                                "Eliminated the merged void cell {cell.label} from [VOLUME] section"
+                                f"Eliminated the merged void cell {cell.label} from [VOLUME] section"
                             )
                         else:
                             vol += f"{'':6s}{cell.label}{'':6s}1.0\n"
@@ -578,9 +578,7 @@ $ **************************************************************
 
         if p.Index not in self.surfaceTable.keys():
             logger.info(
-                f"{p.Type} Surface {p.Index} not used in cell definition)",
-                p.Surf.Axis,
-                p.Surf.Position,
+                f"{p.Type} Surface {p.Index} not used in cell definition) {p.Surf.Axis} {p.Surf.Position}"
             )
             return
 

--- a/src/geouned/GEOUNED/Write/SerpentFormat.py
+++ b/src/geouned/GEOUNED/Write/SerpentFormat.py
@@ -344,7 +344,8 @@ class SerpentInput:
 
         if p.Index not in self.surfaceTable.keys():
             logger.info(
-                f"{p.Type} Surface {p.Index} not used in cell definition) {p.Surf.Axis} {p.Surf.Position}")
+                f"{p.Type} Surface {p.Index} not used in cell definition) {p.Surf.Axis} {p.Surf.Position}"
+            )
             return
 
         for ic in self.surfaceTable[p.Index]:

--- a/src/geouned/GEOUNED/Write/SerpentFormat.py
+++ b/src/geouned/GEOUNED/Write/SerpentFormat.py
@@ -344,10 +344,7 @@ class SerpentInput:
 
         if p.Index not in self.surfaceTable.keys():
             logger.info(
-                f"{p.Type} Surface {p.Index} not used in cell definition)",
-                p.Surf.Axis,
-                p.Surf.Position,
-            )
+                f"{p.Type} Surface {p.Index} not used in cell definition) {p.Surf.Axis} {p.Surf.Position}")
             return
 
         for ic in self.surfaceTable[p.Index]:

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -358,12 +358,10 @@ class CadToCsg:
     def start(self):
 
         logger.info("start")
-        FreeCAD_Version = "{V[0]:}.{V[1]:}.{V[2]:}".format(V=FreeCAD.Version())
+        freecad_version = ".".join(FreeCAD.Version()[:3])
         logger.info(
-            "GEOUNED version {} {} \nFreeCAD version {}".format(
-                GEOUNED_Version, GEOUNED_ReleaseDate, FreeCAD_Version
+            f"GEOUNED version {GEOUNED_Version} {GEOUNED_ReleaseDate} \nFreeCAD version {freecad_version}"
             )
-        )
 
         code_setting = self.__dict__
         if code_setting is None:

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -385,7 +385,7 @@ class CadToCsg:
             step_files = [self.stepFile]
         MetaChunk = []
         EnclosureChunk = []
-        for stp in tqdm(step_files, desc="loading CAD files"):
+        for stp in tqdm(step_files, desc="Loading CAD files"):
             logger.info(f"read step file : {stp}")
             Meta, Enclosure = Load.load_cad(stp, self.matFile)
             MetaChunk.append(Meta)
@@ -446,7 +446,7 @@ class CadToCsg:
 
             # start Building CGS cells phase
 
-            for j, m in enumerate(tqdm(MetaList, desc="translating solid cells")):
+            for j, m in enumerate(tqdm(MetaList, desc="Translating solid cells")):
                 if m.IsEnclosure:
                     continue
                 logger.info(f"Building cell: {j+1}")
@@ -511,7 +511,7 @@ class CadToCsg:
                 for s in lst:
                     Surfs[s.Index] = s
 
-            for c in tqdm(MetaList, desc="simplifying"):
+            for c in tqdm(MetaList, desc="Simplifying"):
                 if c.Definition.level == 0 or c.IsEnclosure:
                     continue
                 logger.info(f"simplify cell {c.__id__}")
@@ -594,10 +594,10 @@ class CadToCsg:
 def decompose_solids(MetaList, Surfaces, UniverseBox, setting, meta):
     totsolid = len(MetaList)
     warningSolids = []
-    for i, m in enumerate(tqdm(MetaList, desc="decomposing solids")):
+    for i, m in enumerate(tqdm(MetaList, desc="Decomposing solids")):
         if meta and m.IsEnclosure:
             continue
-        logger.info(f"Decomposing solid: {i + 1}/{totsolid} ")
+        logger.info(f"Decomposing solid: {i + 1}/{totsolid}")
         if setting["debug"]:
             logger.info(m.Comments)
             if not path.exists("debug"):

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -361,7 +361,7 @@ class CadToCsg:
         freecad_version = ".".join(FreeCAD.Version()[:3])
         logger.info(
             f"GEOUNED version {GEOUNED_Version} {GEOUNED_ReleaseDate} \nFreeCAD version {freecad_version}"
-            )
+        )
 
         code_setting = self.__dict__
         if code_setting is None:


### PR DESCRIPTION
Some of the logger.info commands had a , in the line. This was causing the program to error when it came across those lines.

Worryingly our tests didn't catch this bug and it was reported by @akolsek when using the dev branch to translate a large model.

Glad to get it fixed but we should probably also add a few more well chosen step files to the CI. If we chose small geometries which test currently untested parts of the code that would be great. Also we should think about adding some coverage