### PR TITLE
Adding getters setters type checking to Options, Tolerances, NumericFormat class

### DIFF
--- a/src/geouned/GEOUNED/Utils/data_classes.py
+++ b/src/geouned/GEOUNED/Utils/data_classes.py
@@ -270,6 +270,185 @@ class Tolerances:
         self.tor_angle = tor_angle
         self.min_area = min_area
 
+    @property
+    def relativeTol(self):
+        return self._relativeTol
+
+    @relativeTol.setter
+    def relativeTol(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(
+                f"geouned.Tolerances.relativeTol should be a bool, not a {type(value)}"
+            )
+        self._relativeTol = value
+
+    @property
+    def relativePrecision(self):
+        return self._relativePrecision
+
+    @relativePrecision.setter
+    def relativePrecision(self, value: float):
+        if not isinstance(value, float):
+            raise TypeError(
+                f"geouned.Tolerances.relativePrecision should be a float, not a {type(value)}"
+            )
+        self._relativePrecision = value
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value: float):
+        if not isinstance(value, float):
+            raise TypeError(
+                f"geouned.Tolerances.value should be a float, not a {type(value)}"
+            )
+        self._value = value
+
+    @property
+    def distance(self):
+        return self._distance
+
+    @distance.setter
+    def distance(self, distance: float):
+        if not isinstance(distance, float):
+            raise TypeError(
+                f"geouned.Tolerances.distance should be a float, not a {type(distance)}"
+            )
+        self._distance = distance
+
+    @property
+    def angle(self):
+        return self._angle
+
+    @angle.setter
+    def angle(self, angle: float):
+        if not isinstance(angle, float):
+            raise TypeError(
+                f"geouned.Tolerances.angle should be a float, not a {type(angle)}"
+            )
+        self._angle = angle
+
+    @property
+    def pln_distance(self):
+        return self._pln_distance
+
+    @pln_distance.setter
+    def pln_distance(self, pln_distance: float):
+        if not isinstance(pln_distance, float):
+            raise TypeError(
+                f"geouned.Tolerances.pln_distance should be a float, not a {type(pln_distance)}"
+            )
+        self._pln_distance = pln_distance
+
+    @property
+    def cyl_distance(self):
+        return self._cyl_distance
+
+    @cyl_distance.setter
+    def cyl_distance(self, cyl_distance: float):
+        if not isinstance(cyl_distance, float):
+            raise TypeError(
+                f"geouned.Tolerances.cyl_distance should be a float, not a {type(cyl_distance)}"
+            )
+        self._cyl_distance = cyl_distance
+
+    @property
+    def cyl_angle(self):
+        return self._cyl_angle
+
+    @cyl_angle.setter
+    def cyl_angle(self, cyl_angle: float):
+        if not isinstance(cyl_angle, float):
+            raise TypeError(
+                f"geouned.Tolerances.cyl_angle should be a float, not a {type(cyl_angle)}"
+            )
+        self._cyl_angle = cyl_angle
+
+    @property
+    def sph_distance(self):
+        return self._sph_distance
+
+    @sph_distance.setter
+    def sph_distance(self, sph_distance: float):
+        if not isinstance(sph_distance, float):
+            raise TypeError(
+                f"geouned.Tolerances.sph_distance should be a float, not a {type(sph_distance)}"
+            )
+        self._sph_distance = sph_distance
+
+    @property
+    def pln_angle(self):
+        return self._pln_angle
+
+    @pln_angle.setter
+    def pln_angle(self, pln_angle: float):
+        if not isinstance(pln_angle, float):
+            raise TypeError(
+                f"geouned.Tolerances.pln_angle should be a float, not a {type(pln_angle)}"
+            )
+        self._pln_angle = pln_angle
+
+    @property
+    def kne_distance(self):
+        return self._kne_distance
+
+    @kne_distance.setter
+    def kne_distance(self, kne_distance: float):
+        if not isinstance(kne_distance, float):
+            raise TypeError(
+                f"geouned.Tolerances.kne_distance should be a float, not a {type(kne_distance)}"
+            )
+        self._kne_distance = kne_distance
+
+    @property
+    def kne_angle(self):
+        return self._kne_angle
+
+    @kne_angle.setter
+    def kne_angle(self, kne_angle: float):
+        if not isinstance(kne_angle, float):
+            raise TypeError(
+                f"geouned.Tolerances.kne_angle should be a float, not a {type(kne_angle)}"
+            )
+        self._kne_angle = kne_angle
+
+    @property
+    def tor_distance(self):
+        return self._tor_distance
+
+    @tor_distance.setter
+    def tor_distance(self, tor_distance: float):
+        if not isinstance(tor_distance, float):
+            raise TypeError(
+                f"geouned.Tolerances.tor_distance should be a float, not a {type(tor_distance)}"
+            )
+        self._tor_distance = tor_distance
+
+    @property
+    def tor_angle(self):
+        return self._tor_angle
+
+    @tor_angle.setter
+    def tor_angle(self, tor_angle: float):
+        if not isinstance(tor_angle, float):
+            raise TypeError(
+                f"geouned.Tolerances.tor_angle should be a float, not a {type(tor_angle)}"
+            )
+        self._tor_angle = tor_angle
+
+    @property
+    def min_area(self):
+        return self._min_area
+
+    @min_area.setter
+    def min_area(self, min_area: float):
+        if not isinstance(min_area, float):
+            raise TypeError(
+                f"geouned.Tolerances.min_area should be a float, not a {type(min_area)}"
+            )
+        self._min_area = min_area
 
 class NumericFormat:
     """Numerical format options for each of the surface types.

--- a/src/geouned/GEOUNED/Utils/data_classes.py
+++ b/src/geouned/GEOUNED/Utils/data_classes.py
@@ -1,3 +1,5 @@
+from numbers import Real
+
 class Options:
     """A class for containing conversion options
 
@@ -15,13 +17,13 @@ class Options:
             planes. Defaults to True.
         delLastNumber (bool, optional): Deleting the last word in the
             comment if it is a number. Defaults to False.
-        enlargeBox (float, optional): Enlarge box boundary when evaluating
+        enlargeBox (Real, optional): Enlarge box boundary when evaluating
             the constraint table during the simplification of the void cell
             definition. (unit is millimeter). Defaults to 2.
         nPlaneReverse (int, optional): Threshold value to determine whether
             cut with parallel planes should be carried out first. Defaults
             to 0.
-        splitTolerance (float, optional): Fuzzy tolerance value used in the
+        splitTolerance (Real, optional): Fuzzy tolerance value used in the
             FreeCAD function “BOPTools.SplitAPI.slice”. This function is
             used during the solid decomposition process. Defaults to 0.
         scaleUp (bool, optional): Scale up Fuzzy tolerance once get below
@@ -48,9 +50,9 @@ class Options:
         forceCylinder: bool = False,
         newSplitPlane: bool = True,
         delLastNumber: bool = False,
-        enlargeBox: float = 2.0,
+        enlargeBox: Real = 2.0,
         nPlaneReverse: int = 0,
-        splitTolerance: float = 0.0,
+        splitTolerance: Real = 0.0,
         scaleUp: bool = True,
         quadricPY: bool = False,
         Facets: bool = False,
@@ -105,9 +107,11 @@ class Options:
         return self._enlargeBox
 
     @enlargeBox.setter
-    def enlargeBox(self, value: float):
-        if not isinstance(value, float):
-            raise TypeError(f'geouned.Options.enlargeBox should be a float, not a {type(value)}')
+    def enlargeBox(self, value: Real):
+        if not isinstance(value, Real):
+            raise TypeError(f'geouned.Options.enlargeBox should be a Real, not a {type(value)}')
+        if value < 0:
+            raise ValueError(f'geouned.Options.enlargeBox should be above 0, not {value}')
         self._enlargeBox = value
 
     @property
@@ -125,9 +129,11 @@ class Options:
         return self._splitTolerance
 
     @splitTolerance.setter
-    def splitTolerance(self, value: float):
-        if not isinstance(value, float):
-            raise TypeError(f'geouned.Options.splitTolerance should be a float, not a {type(value)}')
+    def splitTolerance(self, value: Real):
+        if not isinstance(value, Real):
+            raise TypeError(f'geouned.Options.splitTolerance should be a Real, not a {type(value)}')
+        if value < 0:
+            raise ValueError(f'geouned.Options.splitTolerance should be above 0, not {value}')
         self._splitTolerance = value
 
     @property

--- a/src/geouned/GEOUNED/Utils/data_classes.py
+++ b/src/geouned/GEOUNED/Utils/data_classes.py
@@ -450,6 +450,7 @@ class Tolerances:
             )
         self._min_area = min_area
 
+
 class NumericFormat:
     """Numerical format options for each of the surface types.
 
@@ -502,3 +503,171 @@ class NumericFormat:
         self.GQ_1to6 = GQ_1to6
         self.GQ_7to9 = GQ_7to9
         self.GQ_10 = GQ_10
+
+    @property
+    def P_abc(self):
+        return self._P_abc
+
+    @P_abc.setter
+    def P_abc(self, P_abc: str):
+        if not isinstance(P_abc, str):
+            raise TypeError(
+                f"geouned.Tolerances.P_abc should be a str, not a {type(P_abc)}"
+            )
+        self._P_abc = P_abc
+
+    @property
+    def P_d(self):
+        return self._P_d
+
+    @P_d.setter
+    def P_d(self, P_d: str):
+        if not isinstance(P_d, str):
+            raise TypeError(
+                f"geouned.Tolerances.P_d should be a str, not a {type(P_d)}"
+            )
+        self._P_d = P_d
+
+    @property
+    def P_xyz(self):
+        return self._P_xyz
+
+    @P_xyz.setter
+    def P_xyz(self, P_xyz: str):
+        if not isinstance(P_xyz, str):
+            raise TypeError(
+                f"geouned.Tolerances.P_xyz should be a str, not a {type(P_xyz)}"
+            )
+        self._P_xyz = P_xyz
+
+    @property
+    def S_r(self):
+        return self._S_r
+
+    @S_r.setter
+    def S_r(self, S_r: str):
+        if not isinstance(S_r, str):
+            raise TypeError(
+                f"geouned.Tolerances.S_r should be a str, not a {type(S_r)}"
+            )
+        self._S_r = S_r
+
+    @property
+    def S_xyz(self):
+        return self._S_xyz
+
+    @S_xyz.setter
+    def S_xyz(self, S_xyz: str):
+        if not isinstance(S_xyz, str):
+            raise TypeError(
+                f"geouned.Tolerances.S_xyz should be a str, not a {type(S_xyz)}"
+            )
+        self._S_xyz = S_xyz
+
+    @property
+    def C_r(self):
+        return self._C_r
+
+    @C_r.setter
+    def C_r(self, C_r: str):
+        if not isinstance(C_r, str):
+            raise TypeError(
+                f"geouned.Tolerances.C_r should be a str, not a {type(C_r)}"
+            )
+        self._C_r = C_r
+
+    @property
+    def C_xyz(self):
+        return self._C_xyz
+
+    @C_xyz.setter
+    def C_xyz(self, C_xyz: str):
+        if not isinstance(C_xyz, str):
+            raise TypeError(
+                f"geouned.Tolerances.C_xyz should be a str, not a {type(C_xyz)}"
+            )
+        self._C_xyz = C_xyz
+
+    @property
+    def K_xyz(self):
+        return self._K_xyz
+
+    @K_xyz.setter
+    def K_xyz(self, K_xyz: str):
+        if not isinstance(K_xyz, str):
+            raise TypeError(
+                f"geouned.Tolerances.K_xyz should be a str, not a {type(K_xyz)}"
+            )
+        self._K_xyz = K_xyz
+
+    @property
+    def K_tan2(self):
+        return self._K_tan2
+
+    @K_tan2.setter
+    def K_tan2(self, K_tan2: str):
+        if not isinstance(K_tan2, str):
+            raise TypeError(
+                f"geouned.Tolerances.K_tan2 should be a str, not a {type(K_tan2)}"
+            )
+        self._K_tan2 = K_tan2
+
+    @property
+    def T_r(self):
+        return self._T_r
+
+    @T_r.setter
+    def T_r(self, T_r: str):
+        if not isinstance(T_r, str):
+            raise TypeError(
+                f"geouned.Tolerances.T_r should be a str, not a {type(T_r)}"
+            )
+        self._T_r = T_r
+
+    @property
+    def T_xyz(self):
+        return self._T_xyz
+
+    @T_xyz.setter
+    def T_xyz(self, T_xyz: str):
+        if not isinstance(T_xyz, str):
+            raise TypeError(
+                f"geouned.Tolerances.T_xyz should be a str, not a {type(T_xyz)}"
+            )
+        self._T_xyz = T_xyz
+
+    @property
+    def GQ_1to6(self):
+        return self._GQ_1to6
+
+    @GQ_1to6.setter
+    def GQ_1to6(self, GQ_1to6: str):
+        if not isinstance(GQ_1to6, str):
+            raise TypeError(
+                f"geouned.Tolerances.GQ_1to6 should be a str, not a {type(GQ_1to6)}"
+            )
+        self._GQ_1to6 = GQ_1to6
+
+    @property
+    def GQ_7to9(self):
+        return self._GQ_7to9
+
+    @GQ_7to9.setter
+    def GQ_7to9(self, GQ_7to9: str):
+        if not isinstance(GQ_7to9, str):
+            raise TypeError(
+                f"geouned.Tolerances.GQ_7to9 should be a str, not a {type(GQ_7to9)}"
+            )
+        self._GQ_7to9 = GQ_7to9
+
+    @property
+    def GQ_10(self):
+        return self._GQ_10
+
+    @GQ_10.setter
+    def GQ_10(self, GQ_10: str):
+        if not isinstance(GQ_10, str):
+            raise TypeError(
+                f"geouned.Tolerances.GQ_10 should be a str, not a {type(GQ_10)}"
+            )
+        self._GQ_10 = GQ_10

--- a/src/geouned/GEOUNED/Utils/data_classes.py
+++ b/src/geouned/GEOUNED/Utils/data_classes.py
@@ -70,6 +70,115 @@ class Options:
         self.prnt3PPlane = prnt3PPlane
         self.forceNoOverlap = forceNoOverlap
 
+    @property
+    def forceCylinder(self):
+        return self._forceCylinder
+
+    @forceCylinder.setter
+    def forceCylinder(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.forceCylinder should be a bool, not a {type(value)}')
+        self._forceCylinder = value
+
+    @property
+    def newSplitPlane(self):
+        return self._newSplitPlane
+
+    @newSplitPlane.setter
+    def newSplitPlane(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.newSplitPlane should be a bool, not a {type(value)}')
+        self._newSplitPlane = value
+
+    @property
+    def delLastNumber(self):
+        return self._delLastNumber
+
+    @delLastNumber.setter
+    def delLastNumber(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.delLastNumber should be a bool, not a {type(value)}')
+        self._delLastNumber = value
+
+    @property
+    def enlargeBox(self):
+        return self._enlargeBox
+
+    @enlargeBox.setter
+    def enlargeBox(self, value: float):
+        if not isinstance(value, float):
+            raise TypeError(f'geouned.Options.enlargeBox should be a float, not a {type(value)}')
+        self._enlargeBox = value
+
+    @property
+    def nPlaneReverse(self):
+        return self._nPlaneReverse
+
+    @nPlaneReverse.setter
+    def nPlaneReverse(self, value: int):
+        if not isinstance(value, int):
+            raise TypeError(f'geouned.Options.nPlaneReverse should be a int, not a {type(value)}')
+        self._nPlaneReverse = value
+
+    @property
+    def splitTolerance(self):
+        return self._splitTolerance
+
+    @splitTolerance.setter
+    def splitTolerance(self, value: float):
+        if not isinstance(value, float):
+            raise TypeError(f'geouned.Options.splitTolerance should be a float, not a {type(value)}')
+        self._splitTolerance = value
+
+    @property
+    def scaleUp(self):
+        return self._scaleUp
+
+    @scaleUp.setter
+    def scaleUp(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.scaleUp should be a bool, not a {type(value)}')
+        self._scaleUp = value
+
+    @property
+    def quadricPY(self):
+        return self._quadricPY
+
+    @quadricPY.setter
+    def quadricPY(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.quadricPY should be a bool, not a {type(value)}')
+        self._quadricPY = value
+
+    @property
+    def Facets(self):
+        return self._Facets
+
+    @Facets.setter
+    def Facets(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.Facets should be a bool, not a {type(value)}')
+        self._Facets = value
+
+    @property
+    def prnt3PPlane(self):
+        return self._prnt3PPlane
+
+    @prnt3PPlane.setter
+    def prnt3PPlane(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.prnt3PPlane should be a bool, not a {type(value)}')
+        self._prnt3PPlane = value
+
+    @property
+    def forceNoOverlap(self):
+        return self._forceNoOverlap
+
+    @forceNoOverlap.setter
+    def forceNoOverlap(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f'geouned.Options.forceNoOverlap should be a bool, not a {type(value)}')
+        self._forceNoOverlap = value
 
 class Tolerances:
     """A class for containing tolerances values

--- a/src/geouned/GEOUNED/Utils/data_classes.py
+++ b/src/geouned/GEOUNED/Utils/data_classes.py
@@ -1,5 +1,6 @@
 from numbers import Real
 
+
 class Options:
     """A class for containing conversion options
 
@@ -79,7 +80,9 @@ class Options:
     @forceCylinder.setter
     def forceCylinder(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.forceCylinder should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.forceCylinder should be a bool, not a {type(value)}"
+            )
         self._forceCylinder = value
 
     @property
@@ -89,7 +92,9 @@ class Options:
     @newSplitPlane.setter
     def newSplitPlane(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.newSplitPlane should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.newSplitPlane should be a bool, not a {type(value)}"
+            )
         self._newSplitPlane = value
 
     @property
@@ -99,7 +104,9 @@ class Options:
     @delLastNumber.setter
     def delLastNumber(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.delLastNumber should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.delLastNumber should be a bool, not a {type(value)}"
+            )
         self._delLastNumber = value
 
     @property
@@ -109,9 +116,13 @@ class Options:
     @enlargeBox.setter
     def enlargeBox(self, value: Real):
         if not isinstance(value, Real):
-            raise TypeError(f'geouned.Options.enlargeBox should be a Real, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.enlargeBox should be a Real, not a {type(value)}"
+            )
         if value < 0:
-            raise ValueError(f'geouned.Options.enlargeBox should be above 0, not {value}')
+            raise ValueError(
+                f"geouned.Options.enlargeBox should be above 0, not {value}"
+            )
         self._enlargeBox = value
 
     @property
@@ -121,7 +132,9 @@ class Options:
     @nPlaneReverse.setter
     def nPlaneReverse(self, value: int):
         if not isinstance(value, int):
-            raise TypeError(f'geouned.Options.nPlaneReverse should be a int, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.nPlaneReverse should be a int, not a {type(value)}"
+            )
         self._nPlaneReverse = value
 
     @property
@@ -131,9 +144,13 @@ class Options:
     @splitTolerance.setter
     def splitTolerance(self, value: Real):
         if not isinstance(value, Real):
-            raise TypeError(f'geouned.Options.splitTolerance should be a Real, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.splitTolerance should be a Real, not a {type(value)}"
+            )
         if value < 0:
-            raise ValueError(f'geouned.Options.splitTolerance should be above 0, not {value}')
+            raise ValueError(
+                f"geouned.Options.splitTolerance should be above 0, not {value}"
+            )
         self._splitTolerance = value
 
     @property
@@ -143,7 +160,9 @@ class Options:
     @scaleUp.setter
     def scaleUp(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.scaleUp should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.scaleUp should be a bool, not a {type(value)}"
+            )
         self._scaleUp = value
 
     @property
@@ -153,7 +172,9 @@ class Options:
     @quadricPY.setter
     def quadricPY(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.quadricPY should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.quadricPY should be a bool, not a {type(value)}"
+            )
         self._quadricPY = value
 
     @property
@@ -163,7 +184,9 @@ class Options:
     @Facets.setter
     def Facets(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.Facets should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.Facets should be a bool, not a {type(value)}"
+            )
         self._Facets = value
 
     @property
@@ -173,7 +196,9 @@ class Options:
     @prnt3PPlane.setter
     def prnt3PPlane(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.prnt3PPlane should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.prnt3PPlane should be a bool, not a {type(value)}"
+            )
         self._prnt3PPlane = value
 
     @property
@@ -183,8 +208,11 @@ class Options:
     @forceNoOverlap.setter
     def forceNoOverlap(self, value: bool):
         if not isinstance(value, bool):
-            raise TypeError(f'geouned.Options.forceNoOverlap should be a bool, not a {type(value)}')
+            raise TypeError(
+                f"geouned.Options.forceNoOverlap should be a bool, not a {type(value)}"
+            )
         self._forceNoOverlap = value
+
 
 class Tolerances:
     """A class for containing tolerances values


### PR DESCRIPTION
This simple PR adds standard class getters and setters to the Options, Tolerances and NumericFormat class

These check the values whenever the user sets them and checks they are the correct type and in some cases above 0

I've also changed the accepted types to Real which allows floats or ints for enlargeBox and splitTolerance  as it appears we are sometimes passing ints and sometimes passing floats to these attributes.

This will be useful in the future as we can migrate the type checking [here ](https://github.com/GEOUNED-org/GEOUNED/blob/17d4500623754d17d12b371eac818ed968cc6dd4/src/geouned/GEOUNED/__init__.py#L288-L344)with more standard way of doing type checking on class attributes.