### PR TITLE
Add settings class

### DIFF
--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -8,14 +8,18 @@ Python API reference
     :members:
     :show-inheritance:
 
+.. autoclass:: NumericFormat
+    :members:
+    :show-inheritance:
+
 .. autoclass:: Options
     :members:
     :show-inheritance:
 
-.. autoclass:: Tolerances
+.. autoclass:: Settings
     :members:
     :show-inheritance:
 
-.. autoclass:: NumericFormat
+.. autoclass:: Tolerances
     :members:
     :show-inheritance:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,36 +18,103 @@ The example makes use of default  attributes.
 .. code-block:: python
 
     import geouned
-    geo = geouned.CadToCsg(stepFile = 'cuboid.stp')
+    geo = geouned.CadToCsg(stepFile='cuboid.stp')
     geo.start()
-    geo.export_csg()
 
-Users can change :meth:`geouned.Options`, :meth:`geouned.Tolerances` and :meth:`geouned.NumericFormat` to suit the conversion desired.
-The following example shows a more complete usage with several default attributes changed.
+Users can change :meth:`geouned.Options`, :meth:`geouned.Settings`, :meth:`geouned.Tolerances` and :meth:`geouned.NumericFormat` to suit the conversion desired.
+The following example shows a usage with every attributes specified.
 
 .. code-block:: python
 
     import geouned
 
     my_options = geouned.Options(
-        forceCylinder=True,
-        splitTolerance=0,
+        forceCylinder=False,
         newSplitPlane=True,
+        delLastNumber=False,
+        enlargeBox=2,
         nPlaneReverse=0,
+        splitTolerance=0,
+        scaleUp=True,
+        quadricPY=False,
+        Facets=False,
+        prnt3PPlane=False,
+        forceNoOverlap=False,
+    )
+
+    my_settings = geouned.Settings(
+        matFile="",
+        voidGen=True,
+        debug=False,
+        compSolids=True,
+        simplify="no",
+        cellRange=[],
+        exportSolids="",
+        minVoidSize=200.0,
+        maxSurf=50,
+        maxBracket=30,
+        voidMat=[],
+        voidExclude=[],
+        startCell=1,
+        startSurf=1,
+        sort_enclosure=False,
     )
 
     my_tolerances = geouned.Tolerances(
-        min_area=0.011
+        relativeTol=False,
+        relativePrecision=0.000001,
+        value=0.000001,
+        distance=0.0001,
+        angle=0.0001,
+        pln_distance=0.0001,
+        pln_angle=0.0001,
+        cyl_distance=0.0001,
+        cyl_angle=0.0001,
+        sph_distance=0.0001,
+        kne_distance=0.0001,
+        kne_angle=0.0001,
+        tor_distance=0.0001,
+        tor_angle=0.0001,
+        min_area=0.01,
     )
     my_numeric_format = geouned.NumericFormat(
-        C_r="13f"
+        P_abc="14.7e",
+        P_d="14.7e",
+        P_xyz="14.7e",
+        S_r="14.7e",
+        S_xyz="14.7e",
+        C_r="12f",
+        C_xyz="12f",
+        K_xyz="13.6e",
+        K_tan2="12f",
+        T_r="14.7e",
+        T_xyz="14.7e",
+        GQ_1to6="18.15f",
+        GQ_7to9="18.15f",
+        GQ_10="18.15f",
     )
 
     geo = geouned.CadToCsg(
-        stepFile='cuboid.stp',
+        stepFile="cuboid.stp,
         options=my_options,
-        tolerances=my_tolerances
-        numeric_format=my_numeric_format
+        settings=my_settings,
+        tolerances=my_tolerances,
+        numeric_format=my_numeric_format,
+        title="Converted with GEOUNED",
+        geometryName="csg",
+        outFormat=(
+            "openMC_XML",
+            "openMC_PY",
+            "serpent",
+            "phits",
+            "mcnp",
+        ),
+        volSDEF=True,
+        volCARD=False,
+        UCARD=None,
+        dummyMat=True,
+        cellCommentFile=False,
+        cellSummaryFile=False,
     )
 
     geo.start()

--- a/src/geouned/GEOUNED/Cuboid/translate.py
+++ b/src/geouned/GEOUNED/Cuboid/translate.py
@@ -95,7 +95,7 @@ def translate(
         if m.IsEnclosure:
             continue
         logger.info(f"Decomposing solid: {i}/{tot_solid}")
-        if setting["debug"]:
+        if setting.debug:
             logger.info(m.Comments)
             if m.IsEnclosure:
                 m.Solids[0].exportStep(f"origEnclosure_{i}.stp")

--- a/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
+++ b/src/geouned/GEOUNED/LoadFile/LoadSTEP.py
@@ -31,7 +31,7 @@ def extract_materials(filename):
     return m_dict
 
 
-def load_cad(filename, mat_filename, options, default_mat=[], comp_solids=True):
+def load_cad(filename, settings, options):
 
     # Set document solid tree options when opening CAD differing from version 0.18
     if int(FreeCAD.Version()[1]) > 18:
@@ -40,11 +40,11 @@ def load_cad(filename, mat_filename, options, default_mat=[], comp_solids=True):
     cad_simplificado_doc = FreeCAD.newDocument("CAD_simplificado")
     Import.insert(filename, "CAD_simplificado")
 
-    if mat_filename != "":
-        if os.path.exists(mat_filename):
-            m_dict = extract_materials(mat_filename)
+    if settings.matFile != "":
+        if os.path.exists(settings.matFile):
+            m_dict = extract_materials(settings.matFile)
         else:
-            logger.info(f"Material definition file {mat_filename} does not exist.")
+            logger.info(f"Material definition file {settings.matFile} does not exist.")
             m_dict = {}
     else:
         m_dict = {}
@@ -128,7 +128,7 @@ def load_cad(filename, mat_filename, options, default_mat=[], comp_solids=True):
 
                 # compSolid Diferent solid of the same cell are stored in the same metaObject (compSolid)
                 # enclosures and envelopes are always stored as compound
-                if comp_solids or encl_label or envel_label:
+                if settings.compSolids or encl_label or envel_label:
 
                     init = i_solid
                     end = i_solid + len(elem.Shape.Solids)
@@ -159,8 +159,8 @@ def load_cad(filename, mat_filename, options, default_mat=[], comp_solids=True):
                                 missing_mat.add(mat_label)
                     else:
                         # logger.warning('No material label associated to solid {}.\nDefault material used instead.'.format(comment))
-                        if default_mat:
-                            meta_list[i_solid].set_material(*default_mat)
+                        if settings.voidMat:
+                            meta_list[i_solid].set_material(*settings.voidMat)
                     if tempre_dil:
                         meta_list[i_solid].set_dilution(float(tempre_dil.group("dil")))
 

--- a/src/geouned/GEOUNED/Utils/data_classes.py
+++ b/src/geouned/GEOUNED/Utils/data_classes.py
@@ -671,3 +671,284 @@ class NumericFormat:
                 f"geouned.Tolerances.GQ_10 should be a str, not a {type(GQ_10)}"
             )
         self._GQ_10 = GQ_10
+
+
+class Settings:
+    """Settings for changing the way the CAD to CSG conversion is done
+    Args:
+        stepFile (str, optional): Name of the CAD file (in STEP format) to
+            be converted. Defaults to "".
+        matFile (str, optional): _description_. Defaults to "".
+        voidGen (bool, optional): Generate voids of the geometry. Defaults
+            to True.
+        debug (bool, optional): Write step files of original and decomposed
+            solids, for each solid in the STEP file. Defaults to False.
+        compSolids (bool, optional): Join subsolids of STEP file as a single
+            compound solid. Step files generated with SpaceClaim have not
+            exactly the same level of solids as FreeCAD. It may a happened
+            that solids defined has separated solids are read by FreeCAD
+            as a single compound solid (and will produce only one MCNP
+            cell). In this case compSolids should be set to False. Defaults
+            to True.
+        simplify (str, optional): Simplify the cell definition considering
+            relative surfaces position and using Boolean logics. Available
+            options are: "no" no optimization, "void" only void cells are
+            simplified. Algorithm is faster but the simplification is not
+            optimal. "voidfull" : only void cells are simplified with the
+            most optimal algorithm. The time of the conversion can be
+            multiplied by 5 or more. "full" : all the cells (solids and
+            voids) are simplified. Defaults to "No".
+        cellRange (list, optional): Range of cell to be converted (only one
+            range is allowed, e.g [100,220]). Default all solids are
+            converted. Defaults to [].
+        exportSolids (str, optional): Export CAD solid after reading.
+            The execution is stopped after export, the translation is not
+            carried out. Defaults to "".
+        minVoidSize (float, optional): Minimum size of the edges of the
+            void cell. Units are in mm. Defaults to 200.0.
+        maxSurf (int, optional): #TODO
+        maxBracket (int, optional): Maximum number of brackets (solid
+            complementary) allowed in void cell definition. Defaults to 30.
+        voidMat (list, optional): Assign a material defined by the user
+            instead of void for cells without material definition and the
+            cells generated in the automatic void generation. The format
+            is a 3 valued tuple (mat_label, mat_density, mat_description).
+            Example (100,1e-3,'Air assigned to Void'). Defaults to [].
+        voidExclude (list, optional): #TODO see issue 87. Defaults to [].
+        startCell (int, optional): Starting cell numbering label. Defaults to 1.
+        startSurf (int, optional): Starting surface numbering label. Defaults to 1.
+        sort_enclosure (bool, optional): If enclosures are defined in the
+            CAD models, the voids cells of the enclosure will be located in
+            the output file in the same location where the enclosure solid
+            is located in the CAD solid tree.. Defaults to False.
+    """
+
+    def __init__(
+        self,
+        matFile: str = "",
+        voidGen: bool = True,
+        debug: bool = False,
+        compSolids: bool = True,
+        simplify: str = "no",
+        cellRange: list = [],
+        exportSolids: str = "",
+        minVoidSize: float = 200.0,  # units mm
+        maxSurf: int = 50,
+        maxBracket: int = 30,
+        voidMat: list = [],
+        voidExclude: list = [],
+        startCell: int = 1,
+        startSurf: int = 1,
+        sort_enclosure: bool = False,
+    ):
+
+        self.matFile = matFile
+        self.voidGen = voidGen
+        self.debug = debug
+        self.compSolids = compSolids
+        self.simplify = simplify
+        self.cellRange = cellRange
+        self.exportSolids = exportSolids
+        self.minVoidSize = minVoidSize
+        self.maxSurf = maxSurf
+        self.maxBracket = maxBracket
+        self.voidMat = voidMat
+        self.voidExclude = voidExclude
+        self.startCell = startCell
+        self.startSurf = startSurf
+        self.sort_enclosure = sort_enclosure
+
+    @property
+    def matFile(self):
+        return self._matFile
+
+    @matFile.setter
+    def matFile(self, matFile: str):
+        if not isinstance(matFile, str):
+            raise TypeError(
+                f"geouned.Tolerances.matFile should be a str, not a {type(matFile)}"
+            )
+        self._matFile = matFile
+
+    @property
+    def voidGen(self):
+        return self._voidGen
+
+    @voidGen.setter
+    def voidGen(self, voidGen: bool):
+        if not isinstance(voidGen, bool):
+            raise TypeError(
+                f"geouned.Tolerances.voidGen should be a bool, not a {type(voidGen)}"
+            )
+        self._voidGen = voidGen
+
+    @property
+    def debug(self):
+        return self._debug
+
+    @debug.setter
+    def debug(self, debug: bool):
+        if not isinstance(debug, bool):
+            raise TypeError(
+                f"geouned.Tolerances.debug should be a bool, not a {type(debug)}"
+            )
+        self._debug = debug
+
+    @property
+    def compSolids(self):
+        return self._compSolids
+
+    @compSolids.setter
+    def compSolids(self, compSolids: bool):
+        if not isinstance(compSolids, bool):
+            raise TypeError(
+                f"geouned.Tolerances.compSolids should be a bool, not a {type(compSolids)}"
+            )
+        self._compSolids = compSolids
+
+    @property
+    def simplify(self):
+        return self._simplify
+
+    @simplify.setter
+    def simplify(self, simplify: str):
+        if not isinstance(simplify, str):
+            raise TypeError(
+                f"geouned.Tolerances.simplify should be a str, not a {type(simplify)}"
+            )
+        self._simplify = simplify
+
+    @property
+    def cellRange(self):
+        return self._cellRange
+
+    @cellRange.setter
+    def cellRange(self, cellRange: list):
+        if not isinstance(cellRange, list):
+            raise TypeError(
+                f"geouned.Tolerances.cellRange should be a list, not a {type(cellRange)}"
+            )
+        for entry in cellRange:
+            if not isinstance(entry, int):
+                raise TypeError(
+                    f"geouned.Tolerances.cellRange should be a list of ints, not a {type(entry)}"
+                )
+        self._cellRange = cellRange
+
+    @property
+    def exportSolids(self):
+        return self._exportSolids
+
+    @exportSolids.setter
+    def exportSolids(self, exportSolids: str):
+        if not isinstance(exportSolids, str):
+            raise TypeError(
+                f"geouned.Tolerances.exportSolids should be a str, not a {type(exportSolids)}"
+            )
+        self._exportSolids = exportSolids
+
+    @property
+    def minVoidSize(self):
+        return self._minVoidSize
+
+    @minVoidSize.setter
+    def minVoidSize(self, minVoidSize: float):
+        if not isinstance(minVoidSize, float):
+            raise TypeError(
+                f"geouned.Tolerances.minVoidSize should be a float, not a {type(minVoidSize)}"
+            )
+        self._minVoidSize = minVoidSize
+
+    @property
+    def maxSurf(self):
+        return self._maxSurf
+
+    @maxSurf.setter
+    def maxSurf(self, maxSurf: int):
+        if not isinstance(maxSurf, int):
+            raise TypeError(
+                f"geouned.Tolerances.maxSurf should be a int, not a {type(maxSurf)}"
+            )
+        self._maxSurf = maxSurf
+
+    @property
+    def maxBracket(self):
+        return self._maxBracket
+
+    @maxBracket.setter
+    def maxBracket(self, maxBracket: int):
+        if not isinstance(maxBracket, int):
+            raise TypeError(
+                f"geouned.Tolerances.maxBracket should be a int, not a {type(maxBracket)}"
+            )
+        self._maxBracket = maxBracket
+
+    @property
+    def voidMat(self):
+        return self._voidMat
+
+    @voidMat.setter
+    def voidMat(self, voidMat: list):
+        if not isinstance(voidMat, list):
+            raise TypeError(
+                f"geouned.Tolerances.voidMat should be a list, not a {type(voidMat)}"
+            )
+        for entry in voidMat:
+            if not isinstance(entry, int):
+                raise TypeError(
+                    f"geouned.Tolerances.voidMat should be a list of ints, not a {type(entry)}"
+                )
+        self._voidMat = voidMat
+
+    @property
+    def voidExclude(self):
+        return self._voidExclude
+
+    @voidExclude.setter
+    def voidExclude(self, voidExclude: list):
+        if not isinstance(voidExclude, list):
+            raise TypeError(
+                f"geouned.Tolerances.voidExclude should be a list, not a {type(voidExclude)}"
+            )
+        for entry in voidExclude:
+            if not isinstance(entry, int):
+                raise TypeError(
+                    f"geouned.Tolerances.voidExclude should be a list of ints, not a {type(entry)}"
+                )
+        self._voidExclude = voidExclude
+
+    @property
+    def startCell(self):
+        return self._startCell
+
+    @startCell.setter
+    def startCell(self, startCell: int):
+        if not isinstance(startCell, int):
+            raise TypeError(
+                f"geouned.Tolerances.startCell should be a int, not a {type(startCell)}"
+            )
+        self._startCell = startCell
+
+    @property
+    def startSurf(self):
+        return self._startSurf
+
+    @startSurf.setter
+    def startSurf(self, startSurf: int):
+        if not isinstance(startSurf, int):
+            raise TypeError(
+                f"geouned.Tolerances.startSurf should be a int, not a {type(startSurf)}"
+            )
+        self._startSurf = startSurf
+
+    @property
+    def sort_enclosure(self):
+        return self._sort_enclosure
+
+    @sort_enclosure.setter
+    def sort_enclosure(self, sort_enclosure: bool):
+        if not isinstance(sort_enclosure, bool):
+            raise TypeError(
+                f"geouned.Tolerances.sort_enclosure should be a bool, not a {type(sort_enclosure)}"
+            )
+        self._sort_enclosure = sort_enclosure

--- a/src/geouned/GEOUNED/Void/Void.py
+++ b/src/geouned/GEOUNED/Void/Void.py
@@ -46,8 +46,8 @@ def void_generation(
     )
 
     EnclosureBox = GeounedSolid(None, Box)
-    if setting["voidMat"]:
-        voidMat = setting["voidMat"]
+    if setting.voidMat:
+        voidMat = setting.voidMat
         EnclosureBox.set_material(voidMat[0], voidMat[1], voidMat[2])
 
     # get voids in 0 Level Enclosure (original Universe)
@@ -93,9 +93,7 @@ def void_generation(
         set_graveyard_cell(Surfaces, UniverseBox, options, tolerances, numeric_format)
     )
 
-    return VF.update_void_list(
-        init, voidList, NestedEnclosure, setting["sort_enclosure"]
-    )
+    return VF.update_void_list(init, voidList, NestedEnclosure, setting.sort_enclosure)
 
 
 def get_void_def(
@@ -109,13 +107,13 @@ def get_void_def(
     Lev0=False,
 ):
 
-    maxsurf = setting["maxSurf"]
-    maxbracket = setting["maxBracket"]
-    minSize = setting["minVoidSize"]
+    maxsurf = setting.maxSurf
+    maxbracket = setting.maxBracket
+    minSize = setting.minVoidSize
 
-    if "full" in setting["simplify"].lower():
+    if "full" in setting.simplify.lower():
         simplifyVoid = "full"
-    elif "void" in setting["simplify"].lower():
+    elif "void" in setting.simplify.lower():
         simplifyVoid = "diag"
     else:
         simplifyVoid = "no"

--- a/src/geouned/GEOUNED/Write/MCNPFormat.py
+++ b/src/geouned/GEOUNED/Write/MCNPFormat.py
@@ -17,12 +17,25 @@ logger = logging.getLogger(__name__)
 
 # TODO rename as there are two classes with this name
 class McnpInput:
-    def __init__(self, Meta, Surfaces, setting, options, tolerances, numeric_format):
-        self.Title = setting["title"]
-        self.VolSDEF = setting["volSDEF"]
-        self.VolCARD = setting["volCARD"]
-        self.U0CARD = setting["UCARD"]
-        self.dummyMat = setting["dummyMat"]
+    def __init__(
+        self,
+        Meta,
+        Surfaces,
+        options,
+        tolerances,
+        numeric_format,
+        title,
+        volSDEF,
+        volCARD,
+        UCARD,
+        dummyMat,
+        stepFile,
+    ):
+        self.Title = title
+        self.VolSDEF = volSDEF
+        self.VolCARD = volCARD
+        self.U0CARD = UCARD
+        self.dummyMat = dummyMat
         self.Cells = Meta
         self.options = options
         self.tolerances = tolerances
@@ -34,12 +47,9 @@ class McnpInput:
         }
         self.part = "P"
 
-        self.StepFile = setting["stepFile"]
+        self.StepFile = stepFile
         if isinstance(self.StepFile, (tuple, list)):
             self.StepFile = "; ".join(self.StepFile)
-
-        if self.Title == "":
-            self.Title = self.StepFile
 
         self.__get_surface_table__()
         self.__simplify_planes__(Surfaces)

--- a/src/geouned/GEOUNED/Write/PHITSFormat.py
+++ b/src/geouned/GEOUNED/Write/PHITSFormat.py
@@ -31,22 +31,38 @@ logger = logging.getLogger(__name__)
 
 
 class PhitsInput:
-    def __init__(self, Meta, Surfaces, setting, options, tolerances, numeric_format):
-        self.Title = setting["title"]
-        self.VolSDEF = setting["volSDEF"]
-        self.VolCARD = setting["volCARD"]
-        self.U0CARD = setting["UCARD"]
-        self.DummyMat = setting["dummyMat"]
-        self.Matfile = setting["matFile"]
-        self.voidMat = setting["voidMat"]
-        self.startCell = setting["startCell"]
+    def __init__(
+        self,
+        Meta,
+        Surfaces,
+        options,
+        tolerances,
+        numeric_format,
+        title,
+        volSDEF,
+        volCARD,
+        UCARD,
+        dummyMat,
+        stepFile,
+        matFile,
+        voidMat,
+        startCell,
+    ):
+        self.Title = title
+        self.VolSDEF = volSDEF
+        self.VolCARD = volCARD
+        self.U0CARD = UCARD
+        self.DummyMat = dummyMat
+        self.Matfile = matFile
+        self.voidMat = voidMat
+        self.startCell = startCell
         self.Cells = Meta
         self.tolerances = tolerances
         self.numeric_format = numeric_format
         self.options = options
         self.Options = {"Volume": self.VolCARD, "Universe": self.U0CARD}
 
-        self.StepFile = setting["stepFile"]
+        self.StepFile = stepFile
         if isinstance(self.StepFile, (tuple, list)):
             self.StepFile = "; ".join(self.StepFile)
 

--- a/src/geouned/GEOUNED/Write/SerpentFormat.py
+++ b/src/geouned/GEOUNED/Write/SerpentFormat.py
@@ -15,15 +15,28 @@ logger = logging.getLogger(__name__)
 
 
 class SerpentInput:
-    def __init__(self, Meta, Surfaces, setting, options, tolerances, numeric_format):
+    def __init__(
+        self,
+        Meta,
+        Surfaces,
+        options,
+        tolerances,
+        numeric_format,
+        title,
+        volSDEF,
+        volCARD,
+        UCARD,
+        dummyMat,
+        stepFile,
+    ):
         self.options = options
         self.tolerances = tolerances
         self.numeric_format = numeric_format
-        self.Title = setting["title"]
-        self.VolSDEF = setting["volSDEF"]
-        self.VolCARD = setting["volCARD"]
-        self.U0CARD = setting["UCARD"]
-        self.dummyMat = setting["dummyMat"]
+        self.Title = title
+        self.VolSDEF = volSDEF
+        self.VolCARD = volCARD
+        self.U0CARD = UCARD
+        self.dummyMat = dummyMat
         self.Cells = Meta
         self.Options = {
             "Volume": self.VolCARD,
@@ -32,12 +45,9 @@ class SerpentInput:
         }
         self.part = "p"
 
-        self.StepFile = setting["stepFile"]
+        self.StepFile = stepFile
         if isinstance(self.StepFile, (tuple, list)):
             self.StepFile = "; ".join(self.StepFile)
-
-        if self.Title == "":
-            self.Title = self.StepFile
 
         self.__get_surface_table__()
         self.__simplify_planes__(Surfaces)

--- a/src/geouned/GEOUNED/Write/WriteFiles.py
+++ b/src/geouned/GEOUNED/Write/WriteFiles.py
@@ -6,28 +6,42 @@ from .SerpentFormat import SerpentInput
 
 
 def write_geometry(
-    UniverseBox, MetaList, Surfaces, code_setting, options, tolerances, numeric_format
+    UniverseBox,
+    MetaList,
+    Surfaces,
+    settings,
+    options,
+    tolerances,
+    numeric_format,
+    geometryName,
+    outFormat,
+    cellCommentFile,
+    cellSummaryFile,
+    title,
+    volSDEF,
+    volCARD,
+    UCARD,
+    dummyMat,
+    stepFile,
 ):
-
-    baseName = code_setting["geometryName"]
 
     # Currently there are two was of setting outFormat (via a .set method and
     # a class attribute. Once we have a single method then move this validating
     # input code to the attribute @setter
     supported_mc_codes = ("mcnp", "openMC_XML", "openMC_PY", "serpent", "phits")
-    for out_format in code_setting["outFormat"]:
+    for out_format in outFormat:
         if out_format not in supported_mc_codes:
             msg = f"outFormat {out_format} not in supported MC codes ({supported_mc_codes})"
             raise ValueError(msg)
 
     # write cells comments in file
-    if code_setting["cellCommentFile"]:
-        OutFiles.comments_write(baseName, MetaList)
-    if code_setting["cellSummaryFile"]:
-        OutFiles.summary_write(baseName, MetaList)
+    if cellCommentFile:
+        OutFiles.comments_write(geometryName, MetaList)
+    if cellSummaryFile:
+        OutFiles.summary_write(geometryName, MetaList)
 
-    if "mcnp" in code_setting["outFormat"]:
-        mcnpFilename = baseName + ".mcnp"
+    if "mcnp" in outFormat:
+        mcnpFilename = geometryName + ".mcnp"
         outBox = (
             UniverseBox.XMin,
             UniverseBox.XMax,
@@ -36,33 +50,40 @@ def write_geometry(
             UniverseBox.ZMin,
             UniverseBox.ZMax,
         )
-        if code_setting["voidGen"]:
+        if settings.voidGen:
             outSphere = (Surfaces["Sph"][-1].Index, Surfaces["Sph"][-1].Surf.Radius)
         else:
             outSphere = None
 
         MCNPfile = McnpInput(
-            MetaList, Surfaces, code_setting, options, tolerances, numeric_format
+            MetaList,
+            Surfaces,
+            options,
+            tolerances,
+            numeric_format,
+            title,
+            volSDEF,
+            volCARD,
+            UCARD,
+            dummyMat,
+            stepFile,
         )
         MCNPfile.set_sdef((outSphere, outBox))
         MCNPfile.write_input(mcnpFilename)
 
-    if (
-        "openMC_XML" in code_setting["outFormat"]
-        or "openMC_PY" in code_setting["outFormat"]
-    ):
+    if "openMC_XML" in outFormat or "openMC_PY" in outFormat:
         OMCFile = OpenmcInput(MetaList, Surfaces, options, tolerances, numeric_format)
 
-    if "openMC_XML" in code_setting["outFormat"]:
-        omcFilename = baseName + ".xml"
+    if "openMC_XML" in outFormat:
+        omcFilename = geometryName + ".xml"
         OMCFile.write_xml(omcFilename)
 
-    if "openMC_PY" in code_setting["outFormat"]:
-        omcFilename = baseName + ".py"
+    if "openMC_PY" in outFormat:
+        omcFilename = geometryName + ".py"
         OMCFile.write_py(omcFilename)
 
-    if "serpent" in code_setting["outFormat"]:
-        serpentFilename = baseName + ".serp"
+    if "serpent" in outFormat:
+        serpentFilename = geometryName + ".serp"
         outBox = (
             UniverseBox.XMin,
             UniverseBox.XMax,
@@ -71,19 +92,29 @@ def write_geometry(
             UniverseBox.ZMin,
             UniverseBox.ZMax,
         )
-        if code_setting["voidGen"]:
+        if settings.voidGen:
             outSphere = (Surfaces["Sph"][-1].Index, Surfaces["Sph"][-1].Surf.Radius)
         else:
             outSphere = None
 
         Serpentfile = SerpentInput(
-            MetaList, Surfaces, code_setting, options, tolerances, numeric_format
+            MetaList,
+            Surfaces,
+            options,
+            tolerances,
+            numeric_format,
+            title,
+            volSDEF,
+            volCARD,
+            UCARD,
+            dummyMat,
+            stepFile,
         )
         # Serpentfile.set_sdef((outSphere,outBox))
         Serpentfile.write_input(serpentFilename)
 
-    if "phits" in code_setting["outFormat"]:
-        phitsFilename = baseName + ".inp"
+    if "phits" in outFormat:
+        phitsFilename = geometryName + ".inp"
         PHITS_outBox = (
             UniverseBox.XMin,
             UniverseBox.XMax,
@@ -92,7 +123,7 @@ def write_geometry(
             UniverseBox.ZMin,
             UniverseBox.ZMax,
         )
-        if code_setting["voidGen"]:
+        if settings.voidGen:
             PHITS_outSphere = (
                 Surfaces["Sph"][-1].Index,
                 Surfaces["Sph"][-1].Surf.Radius,
@@ -101,7 +132,20 @@ def write_geometry(
             PHITS_outSphere = None
 
         PHITSfile = PhitsInput(
-            MetaList, Surfaces, code_setting, options, tolerances, numeric_format
+            MetaList,
+            Surfaces,
+            options,
+            tolerances,
+            numeric_format,
+            title,
+            volSDEF,
+            volCARD,
+            UCARD,
+            dummyMat,
+            stepFile,
+            matFile=settings.matFile,
+            voidMat=settings.voidMat,
+            startCell=settings.startCell,
         )
         # PHITSfile.setSDEF_PHITS((PHITS_outSphere,PHITS_outBox))
         PHITSfile.write_phits(phitsFilename)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -76,16 +76,15 @@ def test_conversion(input_step_file):
         GQ_10="18.15f",
     )
 
-    geo = geouned.CadToCsg(
-        stepFile=f"{input_step_file.resolve()}",
+    my_settings = geouned.Settings(
         matFile="",
         voidGen=True,
         debug=False,
-        compSolids=False,  # changed from the default
+        compSolids=True,
         simplify="no",
         cellRange=[],
         exportSolids="",
-        minVoidSize=100,  # changed from the default
+        minVoidSize=200.0,  # units mm
         maxSurf=50,
         maxBracket=30,
         voidMat=[],
@@ -93,7 +92,12 @@ def test_conversion(input_step_file):
         startCell=1,
         startSurf=1,
         sort_enclosure=False,
+    )
+
+    geo = geouned.CadToCsg(
+        stepFile=f"{input_step_file.resolve()}",
         options=my_options,
+        settings=my_settings,
         tolerances=my_tolerances,
         numeric_format=my_numeric_format,
         title="Converted with GEOUNED",


### PR DESCRIPTION
this PR introduces a settings class to hold many of the class attributes that currently go to CadToCsg

The settings class has been added to the docs in the python api section and the usage example has been updated to show how the settings is used.

I've added doc strings, type hints to the class to provide the good documentation.

I've also added getter and setter methods with some type checking to help guard against incorrect attribute assignment and inform the user when they enter the incorrect type for an attribute