### PR TITLE
Adding export csg method

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,6 +20,7 @@ The example makes use of default  attributes.
     import geouned
     geo = geouned.CadToCsg(stepFile='cuboid.stp')
     geo.start()
+    geo.export_csg()
 
 Users can change :meth:`geouned.Options`, :meth:`geouned.Settings`, :meth:`geouned.Tolerances` and :meth:`geouned.NumericFormat` to suit the conversion desired.
 The following example shows a usage with every attributes specified.
@@ -100,6 +101,11 @@ The following example shows a usage with every attributes specified.
         settings=my_settings,
         tolerances=my_tolerances,
         numeric_format=my_numeric_format,
+    )
+
+    geo.start()
+
+    geo.export_csg(
         title="Converted with GEOUNED",
         geometryName="csg",
         outFormat=(
@@ -116,5 +122,3 @@ The following example shows a usage with every attributes specified.
         cellCommentFile=False,
         cellSummaryFile=False,
     )
-
-    geo.start()

--- a/src/geouned/GEOUNED/__init__.py
+++ b/src/geouned/GEOUNED/__init__.py
@@ -136,7 +136,6 @@ class CadToCsg:
 
         logger.info("End of Monte Carlo code translation phase")
 
-
     def set_configuration(self, configFile=None):
 
         if configFile is None:
@@ -358,7 +357,9 @@ class CadToCsg:
 
         # Select a specific solid range from original STEP solids
         if self.settings.cellRange:
-            self.MetaList = self.MetaList[self.settings.cellRange[0] : self.settings.cellRange[1]]
+            self.MetaList = self.MetaList[
+                self.settings.cellRange[0] : self.settings.cellRange[1]
+            ]
 
         # export in STEP format solids read from input file
         # terminate excution
@@ -600,6 +601,7 @@ class CadToCsg:
 
         logger.info(f"Translation time of solid cells {tempTime1} - {tempTime0}")
         logger.info(f"Translation time of void cells {tempTime2} - {tempTime1}")
+
 
 def decompose_solids(
     MetaList, Surfaces, UniverseBox, setting, meta, options, tolerances, numeric_format

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -100,6 +100,11 @@ def test_conversion(input_step_file):
         settings=my_settings,
         tolerances=my_tolerances,
         numeric_format=my_numeric_format,
+    )
+
+    geo.start()
+
+    geo.export_csg(
         title="Converted with GEOUNED",
         geometryName=f"{output_filename_stem.resolve()}",
         outFormat=(
@@ -109,15 +114,13 @@ def test_conversion(input_step_file):
             "phits",
             "mcnp",
         ),
-        volSDEF=True,  # changed from the default
-        volCARD=False,  # changed from the default
+        volSDEF=True,
+        volCARD=False,
         UCARD=None,
-        dummyMat=True,  # changed from the default
+        dummyMat=True,
         cellCommentFile=False,
-        cellSummaryFile=False,  # changed from the default
+        cellSummaryFile=False,
     )
-
-    geo.start()
 
     for suffix in suffixes:
         assert output_filename_stem.with_suffix(suffix).exists()

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -114,12 +114,12 @@ def test_conversion(input_step_file):
             "phits",
             "mcnp",
         ),
-        volSDEF=True,
-        volCARD=False,
+        volSDEF=True,  # changed from the default
+        volCARD=False,  # changed from the default
         UCARD=None,
-        dummyMat=True,
+        dummyMat=True,  # changed from the default
         cellCommentFile=False,
-        cellSummaryFile=False,
+        cellSummaryFile=False,  # changed from the default
     )
 
     for suffix in suffixes:


### PR DESCRIPTION
This PR adds an export_csg method. Moving the cadtocsg class attributes that are not needed until the end of the process into the export_csg method

This allows users to redo the quick writing to csg file without redoing the computationally intense conversion of the cad

The usage section of the docs have been updated
The tests have been updated