### PR TITLE
added missing args bug

### DIFF
--- a/src/geouned/GEOUNED/Void/VoidBoxClass.py
+++ b/src/geouned/GEOUNED/Void/VoidBoxClass.py
@@ -205,7 +205,7 @@ class VoidBox:
                     tolerances,
                     numeric_format,
                     MakeObj=True,
-                )
+                ), options, tolerances, numeric_format
             )
             TempPieceEnclosure.update_solids(comsolid.Solids)
             Conv.cellDef(

--- a/src/geouned/GEOUNED/Void/VoidBoxClass.py
+++ b/src/geouned/GEOUNED/Void/VoidBoxClass.py
@@ -205,7 +205,10 @@ class VoidBox:
                     tolerances,
                     numeric_format,
                     MakeObj=True,
-                ), options, tolerances, numeric_format
+                ),
+                options,
+                tolerances,
+                numeric_format,
             )
             TempPieceEnclosure.update_solids(comsolid.Solids)
             Conv.cellDef(


### PR DESCRIPTION
@akolsek found a bug where the expand method is being called without a few arguments.

Sorry for missing this.

We could really do with some more CI tests that probe more of the attribute parameters