### PR TITLE
openmc_py and openmc_xml lower case

### DIFF
--- a/docs/usage/python_api_usage.rst
+++ b/docs/usage/python_api_usage.rst
@@ -104,8 +104,8 @@ The following example shows a usage with every attributes specified.
         title="Converted with GEOUNED",
         geometryName="csg",
         outFormat=(
-            "openMC_XML",
-            "openMC_PY",
+            "openmc_xml",
+            "openmc_py",
             "serpent",
             "phits",
             "mcnp",

--- a/docs/usage/python_cli_usage.rst
+++ b/docs/usage/python_cli_usage.rst
@@ -99,7 +99,7 @@ Here is a complete JSON file specification
         "export_csg":{
             "title": "Converted with GEOUNED",
             "geometryName": "csg",
-            "outFormat": ["openMC_XML", "openMC_PY", "serpent", "phits", "mcnp"],
+            "outFormat": ["openmc_xml", "openmc_py", "serpent", "phits", "mcnp"],
             "volSDEF": false,
             "volCARD": true,
             "dummyMat": false,

--- a/scripts/config.ini
+++ b/scripts/config.ini
@@ -6,8 +6,8 @@ stepFile = stepfilename.stp
 geometryName = pieza
 matFile  = materials.txt
 
-# format of the converted geometry : mcnp, openMC_XML, openMC_PY, serpent, phits
-outFormat = mcnp, openMC_PY, openMC_XML
+# format of the converted geometry : mcnp, openmc_xml, openmc_py, serpent, phits
+outFormat = mcnp, openmc_py, openmc_xml
 
 
 [Parameters]

--- a/scripts/configReverse.ini
+++ b/scripts/configReverse.ini
@@ -2,7 +2,7 @@
 inputFile = my_CSG_model
 CADFile = modelCAD
 
-# CSG format allowed are mcnp or openMC_XML
+# CSG format allowed are mcnp or openmc_xml
 inFormat = mcnp      
 
 # box dim in cm

--- a/scripts/geounedClassCall.py
+++ b/scripts/geounedClassCall.py
@@ -18,7 +18,7 @@ GEO = CadToCsg("Conversion Example")
 
 GEO.set("stepFile", stepFileName)
 GEO.set("geometryName", "Placa")
-GEO.set("outFormat", ("mcnp", "openMC_XML"))
+GEO.set("outFormat", ("mcnp", "openmc_xml"))
 GEO.set("planeDistance", 0.05)
 GEO.set("quadricPY", True)
 GEO.set("P_abc", "12f")

--- a/src/geouned/GEOReverse/reverse.py
+++ b/src/geouned/GEOReverse/reverse.py
@@ -34,10 +34,10 @@ def reverse(optFile="configRevese.ini"):
     # get geometry definition from MCNP input
     if inFormat == "mcnp":
         geom = McnpInput(geomfile)
-    elif inFormat == "openMC_XML":
+    elif inFormat == "openmc_xml":
         geom = XmlInput(geomfile)
     else:
-        msg = f"input format type {inFormat} is not supported." 'Supported options are "mcnp" or "openMC_XML"'
+        msg = f"input format type {inFormat} is not supported." 'Supported options are "mcnp" or "openmc_xml"'
         raise ValueError(msg)
 
     CADCells, fails = buildCAD(UnivCell, geom, CADselection)

--- a/src/geouned/GEOUNED/core.py
+++ b/src/geouned/GEOUNED/core.py
@@ -69,8 +69,8 @@ class CadToCsg:
         title: str = "Converted with GEOUNED",
         geometryName: str = "csg",
         outFormat: typing.Tuple[str] = (
-            "openMC_XML",
-            "openMC_PY",
+            "openmc_xml",
+            "openmc_py",
             "serpent",
             "phits",
             "mcnp",
@@ -90,8 +90,8 @@ class CadToCsg:
             geometryName (str, optional): the file stem of the output file(s).
                 Defaults to "converted_with_geouned".
             outFormat (typing.Tuple[str], optional): Format for the output
-                geometry. Available format are: "mcnp", "openMC_XML",
-                "openMC_PY", "phits" and "serpent". Several output format can
+                geometry. Available format are: "mcnp", "openmc_xml",
+                "openmc_py", "phits" and "serpent". Several output format can
                 be written in the same method call. Defaults to output all codes.
             volSDEF (bool, optional):  Write SDEF definition and tally of solid
                 cell for stochastic volume checking. Defaults to False.
@@ -221,9 +221,9 @@ class CadToCsg:
                             if v.lower() == "mcnp":
                                 outFormat.append("mcnp")
                             elif v.lower() == "openmc_xml":
-                                outFormat.append("openMC_XML")
+                                outFormat.append("openmc_xml")
                             elif v.lower() == "openmc_py":
-                                outFormat.append("openMC_PY")
+                                outFormat.append("openmc_py")
                             elif v.lower() == "serpent":
                                 outFormat.append("serpent")
                             elif v.lower() == "phits":

--- a/src/geouned/GEOUNED/write/write_files.py
+++ b/src/geouned/GEOUNED/write/write_files.py
@@ -25,9 +25,6 @@ def write_geometry(
     stepFile,
 ):
 
-    # Currently there are two was of setting outFormat (via a .set method and
-    # a class attribute. Once we have a single method then move this validating
-    # input code to the attribute @setter
     supported_mc_codes = ("mcnp", "openmc_xml", "openmc_py", "serpent", "phits")
     for out_format in outFormat:
         if out_format not in supported_mc_codes:

--- a/src/geouned/GEOUNED/write/write_files.py
+++ b/src/geouned/GEOUNED/write/write_files.py
@@ -28,7 +28,7 @@ def write_geometry(
     # Currently there are two was of setting outFormat (via a .set method and
     # a class attribute. Once we have a single method then move this validating
     # input code to the attribute @setter
-    supported_mc_codes = ("mcnp", "openMC_XML", "openMC_PY", "serpent", "phits")
+    supported_mc_codes = ("mcnp", "openmc_xml", "openmc_py", "serpent", "phits")
     for out_format in outFormat:
         if out_format not in supported_mc_codes:
             msg = f"outFormat {out_format} not in supported MC codes ({supported_mc_codes})"
@@ -71,14 +71,14 @@ def write_geometry(
         MCNPfile.set_sdef((outSphere, outBox))
         MCNPfile.write_input(mcnpFilename)
 
-    if "openMC_XML" in outFormat or "openMC_PY" in outFormat:
+    if "openmc_xml" in outFormat or "openmc_py" in outFormat:
         OMCFile = OpenmcInput(MetaList, Surfaces, options, tolerances, numeric_format)
 
-    if "openMC_XML" in outFormat:
+    if "openmc_xml" in outFormat:
         omcFilename = geometryName + ".xml"
         OMCFile.write_xml(omcFilename)
 
-    if "openMC_PY" in outFormat:
+    if "openmc_py" in outFormat:
         omcFilename = geometryName + ".py"
         OMCFile.write_py(omcFilename)
 

--- a/tests/config_complete_defaults.json
+++ b/tests/config_complete_defaults.json
@@ -66,7 +66,7 @@
     "export_csg":{
         "title": "Converted with GEOUNED",
         "geometryName": "csg",
-        "outFormat": ["openMC_XML", "openMC_PY", "serpent", "phits", "mcnp"],
+        "outFormat": ["openmc_xml", "openmc_py", "serpent", "phits", "mcnp"],
         "volSDEF": false,
         "volCARD": true,
         "dummyMat": false,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -109,8 +109,8 @@ def test_conversion(input_step_file):
         title="Converted with GEOUNED",
         geometryName=f"{output_filename_stem.resolve()}",
         outFormat=(
-            "openMC_XML",
-            "openMC_PY",
+            "openmc_xml",
+            "openmc_py",
             "serpent",
             "phits",
             "mcnp",
@@ -189,7 +189,7 @@ def test_writing_to_new_folders():
     geo = geouned.CadToCsg(stepFile="testing/inputSTEP/BC.stp")
     geo.start()
 
-    for outformat in ["mcnp", "phits", "serpent", "openMC_XML", "openMC_PY"]:
+    for outformat in ["mcnp", "phits", "serpent", "openmc_xml", "openmc_py"]:
         geo.export_csg(
             geometryName=f"tests_outputs/new_folder_for_testing_{outformat}/csg",
             cellCommentFile=False,


### PR DESCRIPTION
When specifying an outFormat most of the codes are in lower case appart from the best one 😉 

currently we need to request openmc outputs with ```openMC_PY``` and ```openMC_XML``` which is a bit tricky to remember which letters are upper case and which are not and also inconsistent with the other codes.

This PR proposes that we change these to be lower case like the other codes

documentation has been updated

There is a nice check in the code so anyone using it will get a reasonable error message if trying the old upper case names

https://github.com/GEOUNED-org/GEOUNED/blob/6daf2e363bfa46c038c191f6a8581dfae07260b7/src/geouned/GEOUNED/write/write_files.py#L31-L35

