### PR TITLE
Added type checking on export csg

### DIFF
--- a/src/geouned/GEOUNED/core.py
+++ b/src/geouned/GEOUNED/core.py
@@ -77,7 +77,7 @@ class CadToCsg:
         ),
         volSDEF: bool = False,
         volCARD: bool = True,
-        UCARD: int = 101,
+        UCARD: typing.Union[int, type(None)] = 101,
         dummyMat: bool = False,
         cellCommentFile: bool = False,
         cellSummaryFile: bool = True,
@@ -109,6 +109,25 @@ class CadToCsg:
             cellSummaryFile (bool, optional): Write an additional file with
                information on the CAD cell translated. Defaults to True.
         """
+
+        if not isinstance(title, str):
+            raise TypeError(f"title should be of type str not {type(title)}")
+
+        if not isinstance(geometryName, str):
+            raise TypeError(f"geometryName should be of type str not {type(geometryName)}")
+
+        if not isinstance(UCARD, int) and not isinstance(UCARD, type(None)):
+            raise TypeError(f"UCARD should be of type bool not {type(UCARD)}")
+
+        for arg, arg_str in (
+            (volSDEF, "volSDEF"),
+            (volCARD, "volCARD"),
+            (dummyMat, "dummyMat"),
+            (cellCommentFile, "cellCommentFile"),
+            (cellSummaryFile, "cellSummaryFile"),
+        ):
+            if not isinstance(arg, bool):
+                raise TypeError(f"{arg} should be of type bool not {type(arg_str)}")
 
         write_geometry(
             UniverseBox=self.UniverseBox,

--- a/src/geouned/GEOUNED/core.py
+++ b/src/geouned/GEOUNED/core.py
@@ -110,12 +110,6 @@ class CadToCsg:
                information on the CAD cell translated. Defaults to True.
         """
 
-        if not isinstance(title, str):
-            raise TypeError(f"title should be of type str not {type(title)}")
-
-        if not isinstance(geometryName, str):
-            raise TypeError(f"geometryName should be of type str not {type(geometryName)}")
-
         if not isinstance(UCARD, int) and not isinstance(UCARD, type(None)):
             raise TypeError(f"UCARD should be of type bool not {type(UCARD)}")
 
@@ -128,6 +122,10 @@ class CadToCsg:
         ):
             if not isinstance(arg, bool):
                 raise TypeError(f"{arg} should be of type bool not {type(arg_str)}")
+
+        for arg, arg_str in ((title, "title"), (geometryName, "geometryName")):
+            if not isinstance(arg, str):
+                raise TypeError(f"{arg} should be of type str not {type(arg_str)}")
 
         write_geometry(
             UniverseBox=self.UniverseBox,

--- a/src/geouned/GEOUNED/core.py
+++ b/src/geouned/GEOUNED/core.py
@@ -111,7 +111,7 @@ class CadToCsg:
         """
 
         if not isinstance(UCARD, int) and not isinstance(UCARD, type(None)):
-            raise TypeError(f"UCARD should be of type bool not {type(UCARD)}")
+            raise TypeError(f"UCARD should be of type int or None not {type(UCARD)}")
 
         for arg, arg_str in (
             (volSDEF, "volSDEF"),


### PR DESCRIPTION
When users make use of export_csg there is no checking that the arguments are the correct type

We have type checking on all the class attributes so it is a shame not to have type checking on this method

This PR adds checks that ensure the user inputs the correct type and if not they get an informative type error message that hopefully helps them correct the input 