### PR TITLE
more concise install with conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![documentation](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation.yml/badge.svg)](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation.yml)
 [![PyPI](https://img.shields.io/pypi/v/geouned?&label=PyPI)](https://pypi.org/project/geouned/)
 
-[![Anaconda-Server Badge](https://anaconda.org/fusion-energy/geouned/badges/version.svg)](https://anaconda.org/fusion-energy/geouned)
-[![Anaconda-Server Badge](https://anaconda.org/fusion-energy/geouned/badges/platforms.svg)](https://anaconda.org/fusion-energy/geouned)
-[![Anaconda-Server Badge](https://anaconda.org/fusion-energy/geouned/badges/downloads.svg)](https://anaconda.org/fusion-energy/geouned)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/geouned/badges/version.svg)](https://anaconda.org/fusion-energy/geouned)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/geouned/badges/platforms.svg)](https://anaconda.org/fusion-energy/geouned)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/geouned/badges/downloads.svg)](https://anaconda.org/fusion-energy/geouned)
 
 # GEOUNED
 A tool to convert from CAD to CSG & CSG to CAD for Monte Carlo transport codes (MCNP & OpenMC).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![documentation](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation.yml/badge.svg)](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation.yml)
 [![PyPI](https://img.shields.io/pypi/v/geouned?&label=PyPI)](https://pypi.org/project/geouned/)
 
+[![Anaconda-Server Badge](https://anaconda.org/fusion-energy/geouned/badges/version.svg)](https://anaconda.org/fusion-energy/geouned)
+[![Anaconda-Server Badge](https://anaconda.org/fusion-energy/geouned/badges/platforms.svg)](https://anaconda.org/fusion-energy/geouned)
+[![Anaconda-Server Badge](https://anaconda.org/fusion-energy/geouned/badges/downloads.svg)](https://anaconda.org/fusion-energy/geouned)
 
 # GEOUNED
 A tool to convert from CAD to CSG & CSG to CAD for Monte Carlo transport codes (MCNP & OpenMC).

--- a/docs/install/install_linux.rst
+++ b/docs/install/install_linux.rst
@@ -41,19 +41,11 @@ Activate the new environment
 
     mamba activate new_env
 
-We have aspirations to create a conda-forge package which will combine these final two steps, but for now FreeCAD and GEOUNED can be installed in two commands.
-Install FreeCAD which is the main dependency
+Install GEOUNED from conda-forge
 
 .. code-block:: sh
 
-    mamba install -c conda-forge freecad
-
-
-Install GEOUNED with pip, we also prefix this with "python -m" to ensure that pip install uses the correct Python interpreter.
-
-.. code-block:: sh
-
-    python -m pip install geouned
+    mamba install -c conda-forge geouned
 
 Then you will be able to run import GEOUNED from within Python
 
@@ -107,19 +99,11 @@ Activate the new environment
 
     conda activate new_env
 
-We have aspirations to create a conda-forge package which will combine these final two steps, but for now FreeCAD and GEOUNED can be installed in two commands.
-Install FreeCAD which is the main dependency
+Install GEOUNED from conda-forge
 
 .. code-block:: sh
 
-    conda install -c conda-forge freecad
-
-
-Install GEOUNED with pip, we also prefix this with "python -m" to ensure that pip install uses the correct Python interpreter.
-
-.. code-block:: sh
-
-    python -m pip install geouned
+    conda install -c conda-forge geouned
 
 Then you will be able to run import GEOUNED from within Python
 

--- a/docs/install/install_windows.rst
+++ b/docs/install/install_windows.rst
@@ -31,19 +31,11 @@ Activate the new environment
 
     mamba activate new_env
 
-We have aspirations to create a conda-forge package which will combine these final two steps, but for now FreeCAD and GEOUNED can be installed in two commands.
-Install FreeCAD which is the main dependency
+Install GEOUNED from conda-forge
 
 .. code-block:: sh
 
-    mamba install -c conda-forge freecad
-
-
-Install GEOUNED with pip, we also prefix this with "python -m" to ensure that pip install uses the correct Python interpreter.
-
-.. code-block:: sh
-
-    python -m pip install geouned
+    mamba install -c conda-forge geouned
 
 Then you will be able to run import GEOUNED from within Python
 
@@ -84,19 +76,11 @@ Activate the new environment
 
     conda activate new_env
 
-We have aspirations to create a conda-forge package which will combine these final two steps, but for now FreeCAD and GEOUNED can be installed in two commands.
-Install FreeCAD which is the main dependency
+Install GEOUNED from conda-forge
 
 .. code-block:: sh
 
-    conda install -c conda-forge freecad
-
-
-Install GEOUNED with pip, we also prefix this with "python -m" to ensure that pip install uses the correct Python interpreter.
-
-.. code-block:: sh
-
-    python -m pip install geouned
+    conda install -c conda-forge geouned
 
 Then you will be able to run import GEOUNED from within Python
 


### PR DESCRIPTION
# Description

Not ready to merge

The conda forge recipe is passing :tada: and subject to review could be merged in. If https://github.com/conda-forge/staged-recipes/pull/26385 gets merged then we can simplify our install instructions.

Installation becomes a one liner, if you have conda/mamba :tada:

```conda install -c conda-forge geouned```

# Fixes issue

closes #177 

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have made corresponding changes to the documentation