### PR TITLE
Update docs badge with new action name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI testing](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/ci.yml)
 [![Upload Python Package](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/python-publish.yml/badge.svg)](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/python-publish.yml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
-[![documentation](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation.yml/badge.svg)](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation.yml)
+[![documentation release](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation_release.yml/badge.svg)](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation_release.yml)
 [![PyPI](https://img.shields.io/pypi/v/geouned?&label=PyPI)](https://pypi.org/project/geouned/)
 
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/geouned/badges/version.svg)](https://anaconda.org/conda-forge/geouned)


### PR DESCRIPTION


# Description

the action name for the documentation has been changed so the badge needs a small update to the URL

# Fixes issue

![Screenshot 2024-06-18 090432](https://github.com/GEOUNED-org/GEOUNED/assets/8583900/fe06a076-af58-42b3-99b9-a9a7c6db4f25)

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [ ] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
