### PR TITLE
fixing auto update of default docs by removed trailing / in path

### DIFF
--- a/.github/workflows/documentation_release.yml
+++ b/.github/workflows/documentation_release.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
+          publish_dir: _build
           # with next rlease of actions-gh-pages
           # issue to allow force_orphan will be fixed
           # https://github.com/peaceiris/actions-gh-pages/issues/455


### PR DESCRIPTION
## Description

When we release a version the default docs should get automatically updated but [this ](https://github.com/GEOUNED-org/GEOUNED/actions/runs/9561799756/workflow)action
However when releasing version 1.2.0 the default docs didn't get automatically updated.

This is the [first time](https://github.com/GEOUNED-org/GEOUNED/actions/workflows/documentation_release.yml) the action has run so it is perhaps not a total surprise 

the "Deploy to github page" stage posted this error but didn't fail
```cp: no such file or directory: /home/runner/work/GEOUNED/GEOUNED/_build//.*```

So I think changing this line
          publish_dir: _build/
to
          publish_dir: _build
will fix the error

I noticed the[ dev documentation updating action](https://github.com/GEOUNED-org/GEOUNED/blob/f7f42791978a5ec7589a209c73d4d8277072f879/.github/workflows/documentation_update_dev.yml#L51) has already had this change implemented and that action runs much more often


# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [ ] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
