### PR TITLE
change default compSolids behaviour

### DIFF
--- a/docs/usage/python_cadtocsg_api_usage.rst
+++ b/docs/usage/python_cadtocsg_api_usage.rst
@@ -42,7 +42,7 @@ The following example shows a usage with every attributes specified.
         matFile="",
         voidGen=True,
         debug=False,
-        compSolids=True,
+        compSolids=False,
         simplify="no",
         exportSolids="",
         minVoidSize=200.0,

--- a/docs/usage/python_cadtocsg_cli_usage.rst
+++ b/docs/usage/python_cadtocsg_cli_usage.rst
@@ -88,7 +88,7 @@ Here is a complete JSON file specification
             "matFile": "",
             "voidGen": true,
             "debug": false,
-            "compSolids": true,
+            "compSolids": false,
             "simplify": "no",
             "exportSolids": "",
             "minVoidSize": 200.0,

--- a/src/geouned/GEOUNED/utils/data_classes.py
+++ b/src/geouned/GEOUNED/utils/data_classes.py
@@ -605,7 +605,7 @@ class Settings:
             that solids defined has separated solids are read by FreeCAD
             as a single compound solid (and will produce only one MCNP
             cell). In this case compSolids should be set to False. Defaults
-            to True.
+            to False.
         simplify (str, optional): Simplify the cell definition considering
             relative surfaces position and using Boolean logics. Available
             options are: "no" no optimization, "void" only void cells are
@@ -641,7 +641,7 @@ class Settings:
         matFile: str = "",
         voidGen: bool = True,
         debug: bool = False,
-        compSolids: bool = True,
+        compSolids: bool = False,
         simplify: str = "no",
         exportSolids: typing.Optional[str] = None,
         minVoidSize: float = 200.0,  # units mm

--- a/tests/config_cadtocsg_complete_defaults.json
+++ b/tests/config_cadtocsg_complete_defaults.json
@@ -53,7 +53,7 @@
         "matFile": "", 
         "voidGen": true, 
         "debug": false, 
-        "compSolids": true, 
+        "compSolids": false, 
         "simplify": "no", 
         "exportSolids": "", 
         "minVoidSize": 200.0, 

--- a/tests/test_cadtocsg.py
+++ b/tests/test_cadtocsg.py
@@ -81,7 +81,7 @@ def test_conversion(input_step_file):
         matFile="",
         voidGen=True,
         debug=False,
-        compSolids=True,
+        compSolids=False,
         simplify="no",
         exportSolids="",
         minVoidSize=200.0,  # units mm


### PR DESCRIPTION
# Description

The default behaviour for compSolids setting was set to True. This leads to solids in a single component being merged in the MCNP model cell definitions. The default should be false to respect the original structure tree. 

# Fixes issue

-

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
