### PR TITLE
fix bug with spherical shape enclosure

### DIFF
--- a/src/geouned/GEOUNED/void/void_box_class.py
+++ b/src/geouned/GEOUNED/void/void_box_class.py
@@ -23,7 +23,7 @@ class VoidBox:
             self.BoundBox = Enclosure
             self.PieceEnclosure = None
         else:
-            self.BoundBox = Enclosure.BoundBox
+            self.BoundBox = Enclosure.optimalBoundingBox()
             self.PieceEnclosure = Enclosure
 
         for m in MetaSolids:


### PR DESCRIPTION
Bad void generation was done when sphere was used as enclosure.