### PR TITLE
Fixed instance checker in voidMat

### DIFF
--- a/src/geouned/GEOUNED/utils/data_classes.py
+++ b/src/geouned/GEOUNED/utils/data_classes.py
@@ -769,10 +769,17 @@ class Settings:
     def voidMat(self, voidMat: list):
         if not isinstance(voidMat, list):
             raise TypeError(f"geouned.Settings.voidMat should be a list, not a {type(voidMat)}")
-        for entry in voidMat:
-            if not isinstance(entry, int):
-                raise TypeError(f"geouned.Settings.voidMat should be a list of ints, not a {type(entry)}")
-        self._voidMat = voidMat
+        if len(voidMat)==0:
+            self._voidMat = voidMat
+        else:
+            if not isinstance(voidMat[0], int):
+                raise TypeError(f"first entry of geouned.Settings.voidMat should be an int, not a {type(entry)}")
+            if not isinstance(voidMat[1], int):
+                if not isinstance(voidMat[1], float):
+                    raise TypeError(f"second entry of geouned.Settings.voidMat should be an int or float, not a {type(entry)}")
+            if not isinstance(voidMat[2], str):
+                raise TypeError(f"third entry of geouned.Settings.voidMat should be a str, not a {type(entry)}")
+            self._voidMat = voidMat
 
     @property
     def voidExclude(self):

--- a/src/geouned/GEOUNED/utils/data_classes.py
+++ b/src/geouned/GEOUNED/utils/data_classes.py
@@ -769,7 +769,7 @@ class Settings:
     def voidMat(self, voidMat: list):
         if not isinstance(voidMat, list):
             raise TypeError(f"geouned.Settings.voidMat should be a list, not a {type(voidMat)}")
-        if len(voidMat)==0:
+        if len(voidMat) == 0:
             self._voidMat = voidMat
         else:
             if not isinstance(voidMat[0], int):

--- a/tests/config_cadtocsg_non_defaults.json
+++ b/tests/config_cadtocsg_non_defaults.json
@@ -13,6 +13,6 @@
     },
     "Settings": {
         "matFile": "non default",
-        "voidMat": [1, -1.0, "Water"]
+        "voidMat": [1, -1.29E-3, "Dry air"]
     }
 }

--- a/tests/config_cadtocsg_non_defaults.json
+++ b/tests/config_cadtocsg_non_defaults.json
@@ -12,6 +12,7 @@
         "P_abc": "15.7e"
     },
     "Settings": {
-        "matFile": "non default"
+        "matFile": "non default",
+        "voidMat": [1, -1.0, "Water"]
     }
 }


### PR DESCRIPTION
Fixed the void mat instance checker to  check for the first entry being an int, second entry being a float or int, and the third entry being a str.

# Description

Please include a summary of the changes and motivation for the changes

# Fixes issue

#263 

# Checklist

- [x] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
