### PR TITLE
Adding the mention of libmamba solver to installation instructions

### DIFF
--- a/docs/install/install_windows.rst
+++ b/docs/install/install_windows.rst
@@ -76,11 +76,17 @@ Activate the new environment
 
     conda activate new_env
 
-Install GEOUNED from conda-forge
+Since one of the GEOUNED dependencies is FreeCAD, classic conda solver of dependencies may significantly slow down the installation. For this reason, it is recommended to install and use conda-libmamba-solver
 
 .. code-block:: sh
 
-    conda install -c conda-forge geouned -y
+    conda install conda-libmamba-solver
+
+Install GEOUNED from conda-forge, forcing the use of libmamba solver
+
+.. code-block:: sh
+
+    conda install -c conda-forge geouned -y --solver=libmamba
 
 Then you will be able to run import GEOUNED from within Python
 


### PR DESCRIPTION
If you are a first-time contributor to GEOUNED, please read our contributing guidelines:
https://github.com/GEOUNED-org/GEOUNED/blob/main/CONTRIBUTING.md

# Description

Following the current instruction, the installation of GEOUNED using Conda can sometimes take a very long time to resolve dependencies. If you have an older version of conda (23.9 or less), the default solver is very slow - it is recommended to install GEOUNED using conda-libmamba-solver, default in conda 23.10 and newer.

# Fixes issue

Solves the issue #278 

# Checklist

- [x ] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x ] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [x ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
