### PR TITLE
Mcnp 6element matrix

### DIFF
--- a/src/geouned/GEOReverse/Modules/MCNPinput.py
+++ b/src/geouned/GEOReverse/Modules/MCNPinput.py
@@ -396,8 +396,8 @@ def getTransMatrix(trsf, unit="", scale=10.0):
         else:
             coeff = trsf[3:9]
         
-        ax3 = FreeCAD.Vector(coeff[0:3]).cross(FreeCAD.Vector(coeff[3:6]))
-        coeff = coeff + (ax3.x, ax3.y, ax3.z)
+        axis = FreeCAD.Vector(coeff[0:3]).cross(FreeCAD.Vector(coeff[3:6]))
+        coeff = coeff + (axis.x, axis.y, axis.z)
         
         trsfMat = FreeCAD.Matrix(
             coeff[0],

--- a/src/geouned/GEOReverse/Modules/MCNPinput.py
+++ b/src/geouned/GEOReverse/Modules/MCNPinput.py
@@ -389,6 +389,34 @@ def getTransMatrix(trsf, unit="", scale=10.0):
             0,
             1,
         )
+    elif len(trsf) == 9:
+        if unit == "*":
+            coeff = tuple(map(math.radians, trsf[3:9]))
+            coeff = tuple(map(math.cos, coeff))
+        else:
+            coeff = trsf[3:9]
+        
+        ax3 = FreeCAD.Vector(coeff[0:3]).cross(FreeCAD.Vector(coeff[3:6]))
+        coeff = coeff + (ax3.x, ax3.y, ax3.z)
+        
+        trsfMat = FreeCAD.Matrix(
+            coeff[0],
+            coeff[3],
+            coeff[6],
+            trsf[0] * scale,
+            coeff[1],
+            coeff[4],
+            coeff[7],
+            trsf[1] * scale,
+            coeff[2],
+            coeff[5],
+            coeff[8],
+            trsf[2] * scale,
+            0,
+            0,
+            0,
+            1,
+        )
     else:
         if unit == "*":
             coeff = tuple(map(math.radians, trsf[3:12]))

--- a/src/geouned/GEOReverse/Modules/MCNPinput.py
+++ b/src/geouned/GEOReverse/Modules/MCNPinput.py
@@ -395,10 +395,10 @@ def getTransMatrix(trsf, unit="", scale=10.0):
             coeff = tuple(map(math.cos, coeff))
         else:
             coeff = trsf[3:9]
-        
+
         axis = FreeCAD.Vector(coeff[0:3]).cross(FreeCAD.Vector(coeff[3:6]))
         coeff = coeff + (axis.x, axis.y, axis.z)
-        
+
         trsfMat = FreeCAD.Matrix(
             coeff[0],
             coeff[3],


### PR DESCRIPTION
# Description

MCNP allows for transformation matrices that specify only 6 elements rather than all 9. GEOUNED needs to compute the last 3 in this case.

Fixes this issue: #251 

# Checklist

- [X] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [x] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works